### PR TITLE
feat(mcp): encrypted session persistence with Privacy Vault pattern

### DIFF
--- a/apps/mcp-server/.env.example
+++ b/apps/mcp-server/.env.example
@@ -19,3 +19,10 @@ SUPABASE_SERVICE_KEY=your-service-role-key-here
 # ---------------------------------------------------------------------------
 NODE_ENV=development
 CLIENT_URL=http://localhost:8080
+
+# ---------------------------------------------------------------------------
+# Encryption — Required for encrypted session persistence (Privacy Vault)
+# ---------------------------------------------------------------------------
+# 256-bit master key for AES-256-GCM encryption of session data.
+# Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+ENCRYPTION_MASTER_KEY=your-64-hex-char-master-key-here

--- a/apps/mcp-server/src/__tests__/crypto.test.ts
+++ b/apps/mcp-server/src/__tests__/crypto.test.ts
@@ -1,0 +1,223 @@
+/*
+ * Copyright (C) 2026 ZakatFlow
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { randomBytes } from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// Server-side Crypto Module Tests
+// ---------------------------------------------------------------------------
+describe('crypto module — AES-256-GCM', () => {
+    const TEST_MASTER_KEY = randomBytes(32).toString('hex');
+
+    beforeEach(() => {
+        vi.resetModules();
+        process.env.ENCRYPTION_MASTER_KEY = TEST_MASTER_KEY;
+    });
+
+    afterEach(() => {
+        delete process.env.ENCRYPTION_MASTER_KEY;
+    });
+
+    it('encrypt returns prefixed ciphertext', async () => {
+        const { encrypt } = await import('../crypto.js');
+        const result = encrypt({ hello: 'world' });
+        expect(result).not.toBeNull();
+        expect(result!).toMatch(/^enc:v1:/);
+    });
+
+    it('decrypt recovers original data', async () => {
+        const { encrypt, decrypt } = await import('../crypto.js');
+        const testData = { cash: 10000, madhab: 'bradford', assets: [1, 2, 3] };
+        const encrypted = encrypt(testData)!;
+        const decrypted = decrypt(encrypted);
+        expect(decrypted).toEqual(testData);
+    });
+
+    it('each encryption produces different ciphertext (unique salt + IV)', async () => {
+        const { encrypt } = await import('../crypto.js');
+        const data = { amount: 5000 };
+        const enc1 = encrypt(data);
+        const enc2 = encrypt(data);
+        expect(enc1).not.toBe(enc2); // Different salt + IV each time
+    });
+
+    it('decrypt returns null for tampered ciphertext', async () => {
+        const { encrypt, decrypt } = await import('../crypto.js');
+        const encrypted = encrypt({ data: 'sensitive' })!;
+
+        // Tamper with the ciphertext
+        const tampered = encrypted.slice(0, -5) + 'XXXXX';
+        const result = decrypt(tampered);
+        expect(result).toBeNull();
+    });
+
+    it('decrypt returns null with wrong master key', async () => {
+        const { encrypt } = await import('../crypto.js');
+        const encrypted = encrypt({ secret: 'data' })!;
+
+        // Change master key
+        vi.resetModules();
+        process.env.ENCRYPTION_MASTER_KEY = randomBytes(32).toString('hex');
+
+        const { decrypt } = await import('../crypto.js');
+        const result = decrypt(encrypted);
+        expect(result).toBeNull();
+    });
+
+    it('isEncrypted correctly identifies encrypted data', async () => {
+        const { encrypt, isEncrypted } = await import('../crypto.js');
+        const encrypted = encrypt({ data: 'test' })!;
+        expect(isEncrypted(encrypted)).toBe(true);
+        expect(isEncrypted('plain text')).toBe(false);
+        expect(isEncrypted('{}')).toBe(false);
+    });
+
+    it('isEncryptionConfigured returns true when key is set', async () => {
+        const { isEncryptionConfigured } = await import('../crypto.js');
+        expect(isEncryptionConfigured()).toBe(true);
+    });
+
+    it('encrypt handles large payloads', async () => {
+        const { encrypt, decrypt } = await import('../crypto.js');
+        const largeData = {
+            items: Array.from({ length: 100 }, (_, i) => ({
+                id: i,
+                name: `Asset ${i}`,
+                value: Math.random() * 100000,
+            })),
+        };
+        const encrypted = encrypt(largeData)!;
+        expect(encrypted).toBeTruthy();
+        const decrypted = decrypt(encrypted);
+        expect(decrypted).toEqual(largeData);
+    });
+
+    it('decrypt handles plain JSON as fallback (unencrypted data)', async () => {
+        const { decrypt } = await import('../crypto.js');
+        const plainJson = JSON.stringify({ checkingAccounts: 5000 });
+        const result = decrypt(plainJson);
+        expect(result).toEqual({ checkingAccounts: 5000 });
+    });
+
+    it('generateMasterKey produces valid 64-char hex string', async () => {
+        const { generateMasterKey } = await import('../crypto.js');
+        const key = generateMasterKey();
+        expect(key).toMatch(/^[0-9a-f]{64}$/);
+    });
+});
+
+describe('crypto module — no master key', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        delete process.env.ENCRYPTION_MASTER_KEY;
+    });
+
+    it('encrypt returns null when master key is not set', async () => {
+        const { encrypt } = await import('../crypto.js');
+        const result = encrypt({ data: 'test' });
+        expect(result).toBeNull();
+    });
+
+    it('isEncryptionConfigured returns false when key is not set', async () => {
+        const { isEncryptionConfigured } = await import('../crypto.js');
+        expect(isEncryptionConfigured()).toBe(false);
+    });
+
+    it('decrypt returns null for encrypted data when key is missing', async () => {
+        const { decrypt } = await import('../crypto.js');
+        const result = decrypt('enc:v1:somefakebase64data');
+        expect(result).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Persistent Session Store Tests
+// ---------------------------------------------------------------------------
+describe('PersistentSessionStore — in-memory behavior', () => {
+
+    beforeEach(async () => {
+        vi.resetModules();
+        // No Supabase configured — tests pure in-memory behavior
+        delete process.env.SUPABASE_URL;
+        delete process.env.SUPABASE_SERVICE_KEY;
+    });
+
+    it('create returns a session with UUID id', async () => {
+        const { PersistentSessionStore } = await import('../session/persistent-store.js');
+        const session = await PersistentSessionStore.create();
+        expect(session.id).toMatch(/^[0-9a-f]{8}-/); // UUID format
+        expect(session.formData).toBeDefined();
+        expect(session.persisted).toBe(false);
+        PersistentSessionStore.clear();
+    });
+
+    it('get returns created session from cache', async () => {
+        const { PersistentSessionStore } = await import('../session/persistent-store.js');
+        const session = await PersistentSessionStore.create();
+        const retrieved = await PersistentSessionStore.get(session.id);
+        expect(retrieved).toBeDefined();
+        expect(retrieved!.id).toBe(session.id);
+        PersistentSessionStore.clear();
+    });
+
+    it('get returns undefined for non-existent session', async () => {
+        const { PersistentSessionStore } = await import('../session/persistent-store.js');
+        const result = await PersistentSessionStore.get('non-existent-id');
+        expect(result).toBeUndefined();
+        PersistentSessionStore.clear();
+    });
+
+    it('update modifies form data', async () => {
+        const { PersistentSessionStore } = await import('../session/persistent-store.js');
+        const session = await PersistentSessionStore.create();
+        const updated = await PersistentSessionStore.update(session.id, {
+            checkingAccounts: 15000,
+        });
+        expect(updated).toBeDefined();
+        expect(updated!.formData.checkingAccounts).toBe(15000);
+        PersistentSessionStore.clear();
+    });
+
+    it('update returns undefined for non-existent session', async () => {
+        const { PersistentSessionStore } = await import('../session/persistent-store.js');
+        const result = await PersistentSessionStore.update('fake-id', {
+            checkingAccounts: 999,
+        });
+        expect(result).toBeUndefined();
+        PersistentSessionStore.clear();
+    });
+
+    it('delete removes session from cache', async () => {
+        const { PersistentSessionStore } = await import('../session/persistent-store.js');
+        const session = await PersistentSessionStore.create();
+        const deleted = await PersistentSessionStore.delete(session.id);
+        expect(deleted).toBe(true);
+        const retrieved = await PersistentSessionStore.get(session.id);
+        expect(retrieved).toBeUndefined();
+        PersistentSessionStore.clear();
+    });
+
+    it('clear removes all sessions', async () => {
+        const { PersistentSessionStore } = await import('../session/persistent-store.js');
+        await PersistentSessionStore.create();
+        await PersistentSessionStore.create();
+        expect(PersistentSessionStore.size()).toBe(2);
+        PersistentSessionStore.clear();
+        expect(PersistentSessionStore.size()).toBe(0);
+    });
+
+    it('create with chatgptUserId stores it on session (no Supabase)', async () => {
+        const { PersistentSessionStore } = await import('../session/persistent-store.js');
+        const session = await PersistentSessionStore.create('chatgpt-user-123', 'Test User');
+        expect(session.chatgptUserId).toBe('chatgpt-user-123');
+        expect(session.zakatflowUserId).toBeUndefined(); // No Supabase = no mapping
+        PersistentSessionStore.clear();
+    });
+});

--- a/apps/mcp-server/src/crypto.ts
+++ b/apps/mcp-server/src/crypto.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2026 ZakatFlow
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+/**
+ * Server-side AES-256-GCM encryption for ChatGPT session data.
+ *
+ * Adapted from the Privacy Vault pattern (apps/web/src/lib/sessionEncryption.ts)
+ * for server-side Node.js crypto. Uses a master key from env vars to derive
+ * per-encryption DEKs.
+ *
+ * Key hierarchy:
+ *   ENCRYPTION_MASTER_KEY (env var, 64 hex chars = 256 bits)
+ *     → scrypt(master_key + salt) → DEK (per-encryption)
+ *       → AES-256-GCM(DEK, IV, plaintext) → ciphertext
+ *
+ * Envelope format (base64-encoded):
+ *   [salt:16][iv:12][authTag:16][ciphertext:N]
+ *
+ * Compatible with the web app's Privacy Vault encryption standard.
+ */
+
+import {
+    createCipheriv,
+    createDecipheriv,
+    randomBytes,
+    scryptSync,
+} from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 12;          // 96-bit IV for GCM
+const AUTH_TAG_LENGTH = 16;    // 128-bit authentication tag
+const SALT_LENGTH = 16;        // 128-bit salt for scrypt key derivation
+const KEY_LENGTH = 32;         // 256-bit key
+const SCRYPT_COST = 16384;     // N parameter for scrypt (2^14)
+const SCRYPT_BLOCK_SIZE = 8;   // r parameter
+const SCRYPT_PARALLELISM = 1;  // p parameter
+const ENCRYPTED_PREFIX = 'enc:v1:'; // Identifies server-encrypted data
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Get the master key from environment. Returns null if not configured.
+ */
+function getMasterKey(): Buffer | null {
+    const key = process.env.ENCRYPTION_MASTER_KEY;
+    if (!key) return null;
+
+    // Accept 64 hex chars (256 bits) or raw 32-byte base64
+    if (/^[0-9a-fA-F]{64}$/.test(key)) {
+        return Buffer.from(key, 'hex');
+    }
+    const buf = Buffer.from(key, 'base64');
+    if (buf.length === KEY_LENGTH) return buf;
+
+    console.error('[Crypto] ENCRYPTION_MASTER_KEY must be 64 hex chars or 32-byte base64');
+    return null;
+}
+
+/**
+ * Derive an encryption key from the master key using scrypt.
+ */
+function deriveKey(masterKey: Buffer, salt: Buffer): Buffer {
+    return scryptSync(masterKey, salt, KEY_LENGTH, {
+        N: SCRYPT_COST,
+        r: SCRYPT_BLOCK_SIZE,
+        p: SCRYPT_PARALLELISM,
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Check if server-side encryption is available.
+ */
+export function isEncryptionConfigured(): boolean {
+    return getMasterKey() !== null;
+}
+
+/**
+ * Encrypt a JSON-serializable value using AES-256-GCM.
+ *
+ * @param data - Any JSON-serializable value
+ * @returns Base64-encoded ciphertext with `enc:v1:` prefix, or null if encryption is not configured
+ */
+export function encrypt(data: unknown): string | null {
+    const masterKey = getMasterKey();
+    if (!masterKey) {
+        console.warn('[Crypto] Encryption not configured. Data stored in plaintext.');
+        return null;
+    }
+
+    const salt = randomBytes(SALT_LENGTH);
+    const iv = randomBytes(IV_LENGTH);
+    const dek = deriveKey(masterKey, salt);
+
+    const cipher = createCipheriv(ALGORITHM, dek, iv, { authTagLength: AUTH_TAG_LENGTH });
+    const plaintext = JSON.stringify(data);
+
+    const encrypted = Buffer.concat([
+        cipher.update(plaintext, 'utf8'),
+        cipher.final(),
+    ]);
+    const authTag = cipher.getAuthTag();
+
+    // Envelope: salt + iv + authTag + ciphertext
+    const envelope = Buffer.concat([salt, iv, authTag, encrypted]);
+
+    return ENCRYPTED_PREFIX + envelope.toString('base64');
+}
+
+/**
+ * Decrypt a value encrypted with `encrypt()`.
+ *
+ * @param encryptedData - The `enc:v1:` prefixed ciphertext
+ * @returns Parsed JSON value, or null if decryption fails
+ */
+export function decrypt<T = unknown>(encryptedData: string): T | null {
+    if (!encryptedData.startsWith(ENCRYPTED_PREFIX)) {
+        // Not encrypted — try to parse as plain JSON
+        try {
+            return JSON.parse(encryptedData) as T;
+        } catch {
+            return null;
+        }
+    }
+
+    const masterKey = getMasterKey();
+    if (!masterKey) {
+        console.error('[Crypto] Cannot decrypt: ENCRYPTION_MASTER_KEY not configured');
+        return null;
+    }
+
+    try {
+        const envelope = Buffer.from(
+            encryptedData.slice(ENCRYPTED_PREFIX.length),
+            'base64'
+        );
+
+        // Extract components
+        const salt = envelope.subarray(0, SALT_LENGTH);
+        const iv = envelope.subarray(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
+        const authTag = envelope.subarray(
+            SALT_LENGTH + IV_LENGTH,
+            SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH
+        );
+        const ciphertext = envelope.subarray(SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH);
+
+        // Derive the same key
+        const dek = deriveKey(masterKey, salt);
+
+        const decipher = createDecipheriv(ALGORITHM, dek, iv, { authTagLength: AUTH_TAG_LENGTH });
+        decipher.setAuthTag(authTag);
+
+        const decrypted = Buffer.concat([
+            decipher.update(ciphertext),
+            decipher.final(),
+        ]);
+
+        return JSON.parse(decrypted.toString('utf8')) as T;
+    } catch (e) {
+        console.error('[Crypto] Decryption failed:', (e as Error).message);
+        return null;
+    }
+}
+
+/**
+ * Check if a string is server-encrypted data.
+ */
+export function isEncrypted(data: string): boolean {
+    return data.startsWith(ENCRYPTED_PREFIX);
+}
+
+/**
+ * Generate a new random master key (for initial setup).
+ * Returns 64 hex characters suitable for ENCRYPTION_MASTER_KEY env var.
+ */
+export function generateMasterKey(): string {
+    return randomBytes(KEY_LENGTH).toString('hex');
+}

--- a/apps/mcp-server/src/session/persistent-store.ts
+++ b/apps/mcp-server/src/session/persistent-store.ts
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) 2026 ZakatFlow
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+/**
+ * Persistent session store that backs the in-memory SessionStore with
+ * Supabase persistence and server-side encryption.
+ *
+ * Architecture:
+ *   1. In-memory Map is the primary read store (fast)
+ *   2. On create/update, data is encrypted and written to Supabase async
+ *   3. On get (miss), data is fetched from Supabase and decrypted
+ *
+ * This replaces the standalone in-memory SessionStore with a durable,
+ * encrypted backend while maintaining the same API contract.
+ */
+
+import { ZakatFormData, defaultFormData } from '@zakatflow/core';
+import { v4 as uuidv4 } from 'uuid';
+import { getSupabaseAdmin } from '../supabase.js';
+import { encrypt, decrypt, isEncryptionConfigured } from '../crypto.js';
+import {
+    findOrCreateChatGPTUser,
+    saveSession as saveSessionToDb,
+} from '../identity/chatgpt.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ZakatSessionState {
+    id: string;
+    chatgptUserId?: string;      // From OpenAI Apps SDK context
+    zakatflowUserId?: string;    // Internal UUID from chatgpt_users table
+    formData: ZakatFormData;
+    lastUpdated: number;
+    persisted: boolean;          // Whether this session has been written to Supabase
+}
+
+// ---------------------------------------------------------------------------
+// In-memory store (primary read cache)
+// ---------------------------------------------------------------------------
+const sessions = new Map<string, ZakatSessionState>();
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export const PersistentSessionStore = {
+    /**
+     * Create a new session, optionally linking to a ChatGPT user.
+     *
+     * @param chatgptUserId - Optional ChatGPT user ID from Apps SDK context
+     * @param displayName - Optional display name
+     */
+    create: async (
+        chatgptUserId?: string,
+        displayName?: string
+    ): Promise<ZakatSessionState> => {
+        const id = uuidv4();
+
+        // Resolve ChatGPT user identity (if provided and Supabase configured)
+        let zakatflowUserId: string | undefined;
+        if (chatgptUserId) {
+            const user = await findOrCreateChatGPTUser(chatgptUserId, displayName);
+            zakatflowUserId = user?.id;
+        }
+
+        const session: ZakatSessionState = {
+            id,
+            chatgptUserId,
+            zakatflowUserId,
+            formData: { ...defaultFormData },
+            lastUpdated: Date.now(),
+            persisted: false,
+        };
+
+        sessions.set(id, session);
+        return session;
+    },
+
+    /**
+     * Get a session by ID.
+     * First checks in-memory cache, then falls back to Supabase.
+     */
+    get: async (id: string): Promise<ZakatSessionState | undefined> => {
+        // Cache hit
+        const cached = sessions.get(id);
+        if (cached) return cached;
+
+        // Try Supabase fallback
+        const supabase = getSupabaseAdmin();
+        if (!supabase) return undefined;
+
+        const { data, error } = await supabase
+            .from('chatgpt_sessions')
+            .select('*')
+            .eq('id', id)
+            .maybeSingle();
+
+        if (error || !data) return undefined;
+
+        // Decrypt session_data if encrypted
+        let formData: ZakatFormData;
+        if (typeof data.session_data === 'string') {
+            const decrypted = decrypt<ZakatFormData>(data.session_data);
+            formData = decrypted || { ...defaultFormData };
+        } else if (data.session_data && typeof data.session_data === 'object') {
+            formData = data.session_data as unknown as ZakatFormData;
+        } else {
+            formData = { ...defaultFormData };
+        }
+
+        // Populate cache
+        const session: ZakatSessionState = {
+            id: data.id,
+            zakatflowUserId: data.user_id,
+            formData,
+            lastUpdated: new Date(data.updated_at).getTime(),
+            persisted: true,
+        };
+
+        sessions.set(id, session);
+        return session;
+    },
+
+    /**
+     * Update a session's form data.
+     * Writes encrypted data to Supabase if the session has a linked user.
+     */
+    update: async (
+        id: string,
+        updates: Partial<ZakatFormData>
+    ): Promise<ZakatSessionState | undefined> => {
+        const session = sessions.get(id);
+        if (!session) return undefined;
+
+        session.formData = { ...session.formData, ...updates };
+        session.lastUpdated = Date.now();
+        sessions.set(id, session);
+
+        // Persist to Supabase if user is linked
+        if (session.zakatflowUserId) {
+            await PersistentSessionStore.persist(session);
+        }
+
+        return session;
+    },
+
+    /**
+     * Persist a session to Supabase with encryption.
+     */
+    persist: async (session: ZakatSessionState): Promise<void> => {
+        if (!session.zakatflowUserId) return;
+
+        const supabase = getSupabaseAdmin();
+        if (!supabase) return;
+
+        // Encrypt the form data
+        const encryptedData = encrypt(session.formData);
+        const sessionData = encryptedData || session.formData;
+
+        if (session.persisted) {
+            // Update existing row
+            await supabase
+                .from('chatgpt_sessions')
+                .update({
+                    session_data: sessionData,
+                    methodology: session.formData.madhab || 'bradford',
+                    updated_at: new Date().toISOString(),
+                })
+                .eq('id', session.id);
+        } else {
+            // Insert new row
+            const { data, error } = await supabase
+                .from('chatgpt_sessions')
+                .insert({
+                    id: session.id,
+                    user_id: session.zakatflowUserId,
+                    session_data: sessionData,
+                    methodology: session.formData.madhab || 'bradford',
+                })
+                .select('id')
+                .maybeSingle();
+
+            if (!error && data) {
+                session.persisted = true;
+            }
+        }
+    },
+
+    /**
+     * Delete a session from memory and Supabase.
+     */
+    delete: async (id: string): Promise<boolean> => {
+        const session = sessions.get(id);
+        sessions.delete(id);
+
+        if (session?.persisted) {
+            const supabase = getSupabaseAdmin();
+            if (supabase) {
+                await supabase
+                    .from('chatgpt_sessions')
+                    .delete()
+                    .eq('id', id);
+            }
+        }
+
+        return !!session;
+    },
+
+    /**
+     * Clear all in-memory sessions (for testing).
+     */
+    clear: (): void => {
+        sessions.clear();
+    },
+
+    /**
+     * Get count of in-memory sessions (for monitoring).
+     */
+    size: (): number => {
+        return sessions.size;
+    },
+};


### PR DESCRIPTION
## Summary
Closes #27 (Parent: #24) — Completes Phase 1: MCP Server Upgrade

Server-side AES-256-GCM encryption for ChatGPT session data, adapted from the Privacy Vault.

## New Files
- **`apps/mcp-server/src/crypto.ts`** — AES-256-GCM with scrypt KDF from `ENCRYPTION_MASTER_KEY` env var. Envelope: `salt(16)+iv(12)+authTag(16)+ciphertext`. Graceful plaintext fallback.
- **`apps/mcp-server/src/session/persistent-store.ts`** — `PersistentSessionStore` combining in-memory cache + encrypted Supabase writes + decrypted reads on cache miss.
- **`apps/mcp-server/src/__tests__/crypto.test.ts`** — 21 new tests

## Security
- Master key from env var only (64 hex chars = 256 bits)
- Per-encryption unique salt + IV (never reused)
- scrypt KDF: N=16384, r=8, p=1
- GCM authentication tag prevents tampering
- Graceful fallback: plaintext when encryption unconfigured

## Verification
- [x] 49/49 tests passed (1.10s)
- [x] Encrypt/decrypt round-trip verified
- [x] Tamper detection verified (modified ciphertext → null)
- [x] Wrong key rejection verified
- [x] Large payload handling verified