### PR TITLE
feat(widget): polish 3 widget components with animations and premium design

### DIFF
--- a/apps/chatgpt-widget/src/App.tsx
+++ b/apps/chatgpt-widget/src/App.tsx
@@ -4,53 +4,68 @@
  * AGPL-3.0-or-later
  */
 
-import { useApp, useHostStyleVariables, useDocumentTheme } from '@modelcontextprotocol/ext-apps/react';
+import { useApp, useHostStyleVariables } from '@modelcontextprotocol/ext-apps/react';
 import { ZakatResultCard } from './components/ZakatResultCard';
 import { MethodologyComparisonCard } from './components/MethodologyComparisonCard';
-import type { ZakatResult, ComparisonResult } from './types';
+import { SessionProgressCard } from './components/SessionProgressCard';
+import type { ZakatResult, ComparisonResult, SessionProgress } from './types';
 import { useState, useCallback } from 'react';
 
 /**
  * Root App component for the ZakatFlow ChatGPT widget.
  *
  * Connects to the MCP Apps bridge via useApp hook, receives tool results
- * as structuredContent, and renders the appropriate widget card.
+ * via app.ontoolresult, and renders the appropriate widget card:
+ * - calculate_zakat → ZakatResultCard
+ * - compare_madhabs → MethodologyComparisonCard
+ * - add_asset / session updates → SessionProgressCard
  */
 export function App() {
     const [zakatResult, setZakatResult] = useState<ZakatResult | null>(null);
     const [comparison, setComparison] = useState<ComparisonResult | null>(null);
+    const [sessionProgress, setSessionProgress] = useState<SessionProgress | null>(null);
+
+    const handleToolResult = useCallback((toolResult: { structuredContent?: unknown }) => {
+        const content = toolResult?.structuredContent;
+        if (!content || typeof content !== 'object') return;
+
+        const data = content as Record<string, unknown>;
+
+        if (data.type === 'comparison' && Array.isArray(data.comparisons)) {
+            setComparison(data as unknown as ComparisonResult);
+            setZakatResult(null);
+            setSessionProgress(null);
+        } else if (data.type === 'session_progress' && Array.isArray(data.assets)) {
+            setSessionProgress(data as unknown as SessionProgress);
+        } else if (typeof data.zakatDue === 'number') {
+            setZakatResult(data as unknown as ZakatResult);
+            setComparison(null);
+            setSessionProgress(null);
+        }
+    }, []);
 
     const { app, isConnected, error } = useApp({
         appInfo: {
             name: 'ZakatFlow Calculator',
-            version: '0.1.0',
+            version: '0.2.0',
         },
         capabilities: {},
-        onToolResult: useCallback((toolResult: { toolName: string; result: { structuredContent?: unknown } }) => {
-            const content = toolResult.result?.structuredContent;
-            if (!content || typeof content !== 'object') return;
-
-            const data = content as Record<string, unknown>;
-
-            if (data.type === 'comparison' && Array.isArray(data.comparisons)) {
-                setComparison(data as unknown as ComparisonResult);
-                setZakatResult(null);
-            } else if (typeof data.zakatDue === 'number') {
-                setZakatResult(data as unknown as ZakatResult);
-                setComparison(null);
-            }
-        }, []),
+        onAppCreated: useCallback((app) => {
+            app.ontoolresult = (result) => {
+                handleToolResult(result);
+            };
+        }, [handleToolResult]),
     });
 
-    // Apply ChatGPT host styles (fonts, colors, spacing)
+    // Apply ChatGPT host styles (fonts, colors, spacing, theme)
     useHostStyleVariables(app);
-    useDocumentTheme(app);
 
     // Error state
     if (error) {
         return (
-            <div className="p-4 text-red-500 text-sm">
-                Widget error: {error.message}
+            <div className="p-4 text-red-500 text-sm animate-fade-in">
+                <p className="font-medium">Widget Error</p>
+                <p className="text-xs mt-1 opacity-75">{error.message}</p>
             </div>
         );
     }
@@ -58,7 +73,7 @@ export function App() {
     // Connecting state
     if (!isConnected) {
         return (
-            <div className="p-4 flex items-center gap-2 text-[var(--zf-text-muted)]">
+            <div className="p-4 flex items-center gap-2.5 text-[var(--zf-text-muted)] animate-fade-in">
                 <div className="w-4 h-4 border-2 border-current border-t-transparent rounded-full animate-spin" />
                 <span className="text-sm">Connecting to ZakatFlow...</span>
             </div>
@@ -66,10 +81,14 @@ export function App() {
     }
 
     // Waiting for first tool result
-    if (!zakatResult && !comparison) {
+    if (!zakatResult && !comparison && !sessionProgress) {
         return (
-            <div className="p-4 text-center text-[var(--zf-text-muted)] text-sm">
-                <p>ZakatFlow widget ready. Waiting for calculation...</p>
+            <div className="p-4 text-center text-[var(--zf-text-muted)] text-sm animate-fade-in">
+                <div className="w-10 h-10 mx-auto mb-2 rounded-xl bg-gradient-to-br from-emerald-500 to-teal-600 flex items-center justify-center text-white text-lg font-bold">
+                    Z
+                </div>
+                <p className="font-medium text-[var(--zf-text)]">ZakatFlow Ready</p>
+                <p className="text-xs mt-0.5">Waiting for calculation...</p>
             </div>
         );
     }
@@ -77,6 +96,7 @@ export function App() {
     // Render appropriate card
     return (
         <div className="p-2">
+            {sessionProgress && <SessionProgressCard session={sessionProgress} />}
             {zakatResult && <ZakatResultCard result={zakatResult} />}
             {comparison && <MethodologyComparisonCard result={comparison} />}
         </div>

--- a/apps/chatgpt-widget/src/components/MethodologyComparisonCard.tsx
+++ b/apps/chatgpt-widget/src/components/MethodologyComparisonCard.tsx
@@ -11,71 +11,114 @@ interface Props {
 }
 
 /**
- * Side-by-side methodology comparison card widget.
- * Shows how different schools of thought affect Zakat calculation.
- *
- * Designed to render inside ChatGPT via the MCP Apps SDK.
- * Full implementation in Issue #29.
+ * Polished methodology comparison card with winner highlight,
+ * animated entries, and key rule badges.
  */
 export function MethodologyComparisonCard({ result }: Props) {
-    const formatCurrency = (value: number) =>
-        new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
+    const fmt = (v: number) =>
+        new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(v);
 
-    const formatPercent = (value: number) => `${(value * 100).toFixed(0)}%`;
+    const fmtPct = (v: number) => `${(v * 100).toFixed(0)}%`;
+
+    // Find the lowest Zakat amount (most conservative)
+    const validEntries = result.comparisons.filter(e => !e.error);
+    const minZakat = Math.min(...validEntries.map(e => e.zakatDue));
+    const maxZakat = Math.max(...validEntries.map(e => e.zakatDue));
 
     return (
-        <div className="border border-[var(--zf-border)] rounded-xl p-5 bg-[var(--zf-card-bg)] shadow-sm">
+        <div className="zf-card animate-fade-in">
             {/* Header */}
-            <div className="mb-4">
-                <h2 className="text-lg font-semibold text-[var(--zf-text)]">
-                    Methodology Comparison
-                </h2>
-                <p className="text-sm text-[var(--zf-text-muted)]">
-                    {result.comparisons.length} schools of thought compared
-                </p>
+            <div className="flex items-center gap-2 mb-1">
+                <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-blue-500 to-indigo-600 flex items-center justify-center text-white text-sm font-bold">
+                    ⚖
+                </div>
+                <div>
+                    <h2 className="text-base font-semibold text-[var(--zf-text)]">
+                        Methodology Comparison
+                    </h2>
+                    <p className="text-xs text-[var(--zf-text-muted)]">
+                        {result.comparisons.length} schools of thought
+                    </p>
+                </div>
             </div>
 
-            {/* Comparison Grid */}
-            <div className="space-y-3">
-                {result.comparisons.map((entry: MethodologyEntry) => (
-                    <div
-                        key={entry.methodologyId}
-                        className="border border-[var(--zf-border)] rounded-lg p-3"
-                    >
-                        {entry.error ? (
-                            <div className="text-sm text-red-500">{entry.error}</div>
-                        ) : (
-                            <>
-                                <div className="flex justify-between items-center mb-2">
-                                    <span className="font-medium text-sm text-[var(--zf-text)]">
-                                        {entry.methodologyName}
-                                    </span>
-                                    <span className="text-lg font-bold text-[var(--zf-text)]">
-                                        {formatCurrency(entry.zakatDue)}
-                                    </span>
-                                </div>
-                                <div className="grid grid-cols-3 gap-1 text-xs text-[var(--zf-text-muted)]">
-                                    <div>
-                                        <span className="block font-medium">Stocks</span>
-                                        {formatPercent(entry.keyRules.passiveInvestmentRate)}
+            {/* Range summary */}
+            {validEntries.length >= 2 && (
+                <div className="flex items-center gap-2 mb-4 px-3 py-2 rounded-lg bg-blue-50 dark:bg-blue-950/20 text-xs text-[var(--zf-text-muted)]">
+                    <span>Range:</span>
+                    <span className="font-semibold text-[var(--zf-text)]">{fmt(minZakat)}</span>
+                    <span>→</span>
+                    <span className="font-semibold text-[var(--zf-text)]">{fmt(maxZakat)}</span>
+                </div>
+            )}
+
+            {/* Comparison Entries */}
+            <div className="space-y-2.5">
+                {result.comparisons.map((entry: MethodologyEntry, i: number) => {
+                    const isLowest = entry.zakatDue === minZakat && !entry.error;
+                    const barWidth = maxZakat > 0 ? (entry.zakatDue / maxZakat) * 100 : 0;
+
+                    return (
+                        <div
+                            key={entry.methodologyId}
+                            className={`relative border rounded-lg p-3 transition-all animate-slide-up ${isLowest
+                                    ? 'border-emerald-300 dark:border-emerald-700 bg-emerald-50/50 dark:bg-emerald-950/10'
+                                    : 'border-[var(--zf-border)]'
+                                }`}
+                            style={{ animationDelay: `${i * 100}ms` }}
+                        >
+                            {entry.error ? (
+                                <div className="text-sm text-red-500">{entry.error}</div>
+                            ) : (
+                                <>
+                                    <div className="flex justify-between items-center mb-2">
+                                        <div className="flex items-center gap-1.5">
+                                            <span className="font-medium text-sm text-[var(--zf-text)]">
+                                                {entry.methodologyName}
+                                            </span>
+                                            {isLowest && (
+                                                <span className="text-[10px] font-medium px-1.5 py-0.5 rounded bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400">
+                                                    Lowest
+                                                </span>
+                                            )}
+                                        </div>
+                                        <span className="text-lg font-bold tabular-nums text-[var(--zf-text)]">
+                                            {fmt(entry.zakatDue)}
+                                        </span>
                                     </div>
-                                    <div>
-                                        <span className="block font-medium">Liabilities</span>
-                                        {entry.keyRules.liabilityMethod.replace(/_/g, ' ')}
+
+                                    {/* Relative bar */}
+                                    <div className="h-1.5 rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden mb-2">
+                                        <div
+                                            className={`h-full rounded-full transition-all duration-700 ease-out ${isLowest
+                                                    ? 'bg-gradient-to-r from-emerald-400 to-teal-400'
+                                                    : 'bg-gradient-to-r from-blue-400 to-indigo-400'
+                                                }`}
+                                            style={{ width: `${barWidth}%` }}
+                                        />
                                     </div>
-                                    <div>
-                                        <span className="block font-medium">Nisab</span>
-                                        {entry.keyRules.nisabStandard}
+
+                                    {/* Key Rules */}
+                                    <div className="flex gap-1.5 flex-wrap">
+                                        <span className="zf-rule-tag">
+                                            Stocks {fmtPct(entry.keyRules.passiveInvestmentRate)}
+                                        </span>
+                                        <span className="zf-rule-tag">
+                                            {entry.keyRules.liabilityMethod.replace(/_/g, ' ')}
+                                        </span>
+                                        <span className="zf-rule-tag">
+                                            {entry.keyRules.nisabStandard} nisab
+                                        </span>
                                     </div>
-                                </div>
-                            </>
-                        )}
-                    </div>
-                ))}
+                                </>
+                            )}
+                        </div>
+                    );
+                })}
             </div>
 
             {/* Disclaimer */}
-            <p className="text-[11px] text-[var(--zf-text-muted)] text-center mt-4">
+            <p className="zf-disclaimer">
                 ZakatFlow provides calculations, not fatwas. Consult a qualified scholar.
             </p>
         </div>

--- a/apps/chatgpt-widget/src/components/SessionProgressCard.tsx
+++ b/apps/chatgpt-widget/src/components/SessionProgressCard.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2026 ZakatFlow
+ *
+ * AGPL-3.0-or-later
+ */
+
+import type { SessionProgress, SessionAsset } from '../types';
+
+interface Props {
+    session: SessionProgress;
+}
+
+const ASSET_ICONS: Record<string, string> = {
+    cash: '💵',
+    gold: '🥇',
+    silver: '🥈',
+    stocks: '📈',
+    retirement: '🏦',
+    loans: '📋',
+};
+
+const ASSET_LABELS: Record<string, string> = {
+    cash: 'Cash & Checking',
+    gold: 'Gold Investments',
+    silver: 'Silver',
+    stocks: 'Stocks & Funds',
+    retirement: 'Retirement Accounts',
+    loans: 'Liabilities',
+};
+
+/**
+ * Interactive session progress card.
+ * Shows the running state of a multi-turn Zakat calculation session,
+ * including added assets, a running total, and the "next step" hint.
+ */
+export function SessionProgressCard({ session }: Props) {
+    const fmt = (v: number) =>
+        new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(v);
+
+    const totalAssets = session.assets
+        .filter(a => a.type !== 'loans')
+        .reduce((sum, a) => sum + a.amount, 0);
+
+    const totalLiabilities = session.assets
+        .filter(a => a.type === 'loans')
+        .reduce((sum, a) => sum + a.amount, 0);
+
+    const progressSteps: SessionAsset['type'][] = ['cash', 'gold', 'stocks', 'retirement', 'loans'];
+    const completedTypes = new Set(session.assets.map(a => a.type));
+    const completedCount = progressSteps.filter(s => completedTypes.has(s)).length;
+
+    return (
+        <div className="zf-card animate-fade-in">
+            {/* Header */}
+            <div className="flex items-center justify-between mb-4">
+                <div className="flex items-center gap-2">
+                    <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-violet-500 to-purple-600 flex items-center justify-center text-white text-sm font-bold">
+                        ✦
+                    </div>
+                    <div>
+                        <h2 className="text-base font-semibold text-[var(--zf-text)]">
+                            Session Progress
+                        </h2>
+                        <p className="text-xs text-[var(--zf-text-muted)]">
+                            {session.assets.length} asset{session.assets.length !== 1 ? 's' : ''} added
+                        </p>
+                    </div>
+                </div>
+                <span className="zf-badge zf-badge--info">
+                    {completedCount}/{progressSteps.length} categories
+                </span>
+            </div>
+
+            {/* Progress dots */}
+            <div className="flex gap-1.5 mb-4">
+                {progressSteps.map((step) => (
+                    <div
+                        key={step}
+                        className={`flex-1 h-1.5 rounded-full transition-colors duration-500 ${completedTypes.has(step as SessionAsset['type'])
+                            ? 'bg-gradient-to-r from-violet-400 to-purple-500'
+                            : 'bg-gray-200 dark:bg-gray-700'
+                            }`}
+                        title={ASSET_LABELS[step] || step}
+                    />
+                ))}
+            </div>
+
+            {/* Assets List */}
+            {session.assets.length > 0 && (
+                <div className="space-y-1.5 mb-4">
+                    {session.assets.map((asset: SessionAsset, i: number) => (
+                        <div
+                            key={`${asset.type}-${i}`}
+                            className="flex items-center justify-between py-1.5 px-2.5 rounded-lg bg-gray-50 dark:bg-gray-800/50 animate-slide-up"
+                            style={{ animationDelay: `${i * 60}ms` }}
+                        >
+                            <div className="flex items-center gap-2">
+                                <span className="text-base">{ASSET_ICONS[asset.type] || '💰'}</span>
+                                <span className="text-sm text-[var(--zf-text)]">
+                                    {ASSET_LABELS[asset.type] || asset.type}
+                                </span>
+                            </div>
+                            <span className={`text-sm font-medium tabular-nums ${asset.type === 'loans'
+                                ? 'text-red-500'
+                                : 'text-[var(--zf-text)]'
+                                }`}>
+                                {asset.type === 'loans' ? '−' : ''}{fmt(asset.amount)}
+                            </span>
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {/* Running Totals */}
+            <div className="border-t border-[var(--zf-border)] pt-3 space-y-1.5">
+                <div className="flex justify-between text-sm">
+                    <span className="text-[var(--zf-text-muted)]">Total Assets</span>
+                    <span className="font-semibold tabular-nums text-[var(--zf-text)]">
+                        {fmt(totalAssets)}
+                    </span>
+                </div>
+                {totalLiabilities > 0 && (
+                    <div className="flex justify-between text-sm">
+                        <span className="text-[var(--zf-text-muted)]">Liabilities</span>
+                        <span className="font-semibold tabular-nums text-red-500">
+                            −{fmt(totalLiabilities)}
+                        </span>
+                    </div>
+                )}
+                {session.runningZakat !== undefined && (
+                    <div className="flex justify-between text-sm pt-1 border-t border-dashed border-[var(--zf-border)]">
+                        <span className="text-[var(--zf-text-muted)]">Estimated Zakat</span>
+                        <span className="font-bold tabular-nums text-transparent bg-clip-text bg-gradient-to-r from-emerald-600 to-teal-600">
+                            {fmt(session.runningZakat)}
+                        </span>
+                    </div>
+                )}
+            </div>
+
+            {/* Next step hint */}
+            {session.nextHint && (
+                <div className="mt-3 px-3 py-2 rounded-lg bg-violet-50 dark:bg-violet-950/20 text-xs text-[var(--zf-text-muted)]">
+                    💡 {session.nextHint}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/apps/chatgpt-widget/src/components/ZakatResultCard.tsx
+++ b/apps/chatgpt-widget/src/components/ZakatResultCard.tsx
@@ -11,60 +11,85 @@ interface Props {
 }
 
 /**
- * Zakat calculation result card widget.
- * Displays the calculated Zakat amount, breakdown, and a deep-link to zakatflow.org.
- *
- * Designed to render inside ChatGPT via the MCP Apps SDK.
- * Full implementation in Issue #29.
+ * Polished Zakat calculation result card.
+ * Displays the calculated Zakat amount with animated breakdown, methodology badge,
+ * nisab progress indicator, and a deep-link CTA to zakatflow.org.
  */
 export function ZakatResultCard({ result }: Props) {
-    const formatCurrency = (value: number) =>
-        new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(value);
+    const fmt = (v: number) =>
+        new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(v);
+
+    const nisabPercent = Math.min(100, (result.netZakatableWealth / result.nisab) * 100);
+
+    const breakdownRows: [string, number][] = [
+        ['Total Assets', result.totalAssets],
+        ['Deductible Liabilities', result.totalLiabilities],
+        ['Net Zakatable Wealth', result.netZakatableWealth],
+        ['Nisab Threshold', result.nisab],
+    ];
 
     return (
-        <div className="border border-[var(--zf-border)] rounded-xl p-5 bg-[var(--zf-card-bg)] shadow-sm">
+        <div className="zf-card animate-fade-in">
             {/* Header */}
             <div className="flex justify-between items-center mb-4">
-                <h2 className="text-lg font-semibold text-[var(--zf-text)]">
-                    Zakat Calculation
-                </h2>
-                <span
-                    className={`text-xs font-medium px-2.5 py-1 rounded-full ${result.isAboveNisab
-                            ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
-                            : 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400'
-                        }`}
-                >
+                <div className="flex items-center gap-2">
+                    <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-emerald-500 to-teal-600 flex items-center justify-center text-white text-sm font-bold">
+                        Z
+                    </div>
+                    <h2 className="text-base font-semibold text-[var(--zf-text)]">
+                        Zakat Calculation
+                    </h2>
+                </div>
+                <span className={`zf-badge ${result.isAboveNisab ? 'zf-badge--success' : 'zf-badge--warning'}`}>
                     {result.isAboveNisab ? result.methodology : 'Below Nisab'}
                 </span>
             </div>
 
-            {/* Amount */}
-            <div className="text-3xl font-bold text-[var(--zf-text)] mb-1">
-                {formatCurrency(result.zakatDue)}
+            {/* Hero Amount */}
+            <div className="text-center py-4 mb-4 rounded-lg bg-gradient-to-r from-emerald-50 to-teal-50 dark:from-emerald-950/20 dark:to-teal-950/20 animate-slide-up">
+                <p className="text-xs uppercase tracking-widest text-[var(--zf-text-muted)] mb-1">
+                    Your Zakat Due
+                </p>
+                <div className="text-4xl font-extrabold text-transparent bg-clip-text bg-gradient-to-r from-emerald-600 to-teal-600 tabular-nums">
+                    {fmt(result.zakatDue)}
+                </div>
+                <p className="text-xs text-[var(--zf-text-muted)] mt-1">
+                    2.5% of net zakatable wealth
+                </p>
             </div>
-            <p className="text-sm text-[var(--zf-text-muted)] mb-4">
-                {result.isAboveNisab
-                    ? `Above nisab threshold (${formatCurrency(result.nisab)})`
-                    : 'Below nisab — no Zakat obligation'}
-            </p>
+
+            {/* Nisab Progress Bar */}
+            <div className="mb-4">
+                <div className="flex justify-between text-xs text-[var(--zf-text-muted)] mb-1">
+                    <span>Nisab threshold</span>
+                    <span>{Math.round(nisabPercent)}%</span>
+                </div>
+                <div className="h-2 rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden">
+                    <div
+                        className={`h-full rounded-full transition-all duration-1000 ease-out ${result.isAboveNisab
+                                ? 'bg-gradient-to-r from-emerald-500 to-teal-500'
+                                : 'bg-gradient-to-r from-orange-400 to-amber-400'
+                            }`}
+                        style={{ width: `${nisabPercent}%` }}
+                    />
+                </div>
+            </div>
 
             {/* Breakdown */}
-            <div className="border-t border-[var(--zf-border)] pt-4 mb-4">
-                <div className="grid grid-cols-2 gap-2 text-sm">
-                    {[
-                        ['Total Assets', result.totalAssets],
-                        ['Deductible Liabilities', result.totalLiabilities],
-                        ['Net Zakatable Wealth', result.netZakatableWealth],
-                        ['Nisab Threshold', result.nisab],
-                    ].map(([label, value]) => (
-                        <div key={label as string} className="flex justify-between col-span-2">
-                            <span className="text-[var(--zf-text-muted)]">{label as string}</span>
-                            <span className="font-medium text-[var(--zf-text)]">
-                                {formatCurrency(value as number)}
-                            </span>
-                        </div>
-                    ))}
-                </div>
+            <div className="border-t border-[var(--zf-border)] pt-3 mb-4 space-y-2">
+                {breakdownRows.map(([label, value], i) => (
+                    <div
+                        key={label}
+                        className="flex justify-between text-sm animate-slide-up"
+                        style={{ animationDelay: `${i * 80}ms` }}
+                    >
+                        <span className="text-[var(--zf-text-muted)]">{label}</span>
+                        <span className={`font-medium tabular-nums ${label === 'Net Zakatable Wealth' ? 'text-[var(--zf-text)] font-semibold' : 'text-[var(--zf-text)]'
+                            }`}>
+                            {fmt(value)}
+                        </span>
+                    </div>
+                ))}
             </div>
 
             {/* CTA */}
@@ -72,13 +97,16 @@ export function ZakatResultCard({ result }: Props) {
                 href={result.reportLink}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="block w-full text-center py-2.5 rounded-lg bg-[var(--zf-primary)] text-white text-sm font-medium hover:bg-[var(--zf-primary-light)] transition-colors no-underline"
+                className="zf-cta group"
             >
-                View Full Report on ZakatFlow.org
+                <span>View Full Report on ZakatFlow.org</span>
+                <svg className="w-4 h-4 transition-transform group-hover:translate-x-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 4.5L21 12m0 0l-7.5 7.5M21 12H3" />
+                </svg>
             </a>
 
             {/* Disclaimer */}
-            <p className="text-[11px] text-[var(--zf-text-muted)] text-center mt-3">
+            <p className="zf-disclaimer">
                 ZakatFlow provides calculations, not fatwas. Consult a qualified scholar.
             </p>
         </div>

--- a/apps/chatgpt-widget/src/index.css
+++ b/apps/chatgpt-widget/src/index.css
@@ -1,19 +1,18 @@
 @import "tailwindcss";
 
 /*
- * ZakatFlow ChatGPT Widget — Design Tokens
- * Uses CSS custom properties for theming compatibility with ChatGPT host styles.
- * The MCP Apps bridge injects --mcp-ui-* variables from the ChatGPT host.
+ * ZakatFlow ChatGPT Widget — Design System
+ * CSS custom properties for theming + MCP host compatibility.
  */
 
 :root {
-    /* Brand Colors */
+    /* Brand */
     --zf-primary: #1a1a2e;
     --zf-primary-light: #2d2d4e;
     --zf-accent: #16a34a;
     --zf-accent-light: #22c55e;
 
-    /* Semantic Colors */
+    /* Semantic */
     --zf-success: #16a34a;
     --zf-warning: #ea580c;
     --zf-info: #2563eb;
@@ -24,13 +23,12 @@
     --zf-card-bg: #ffffff;
     --zf-border: #e2e8f0;
 
-    /* Typography */
+    /* Type */
     --zf-font: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
     --zf-text: #1a1a2e;
     --zf-text-muted: #64748b;
 }
 
-/* Dark mode adaptation via MCP host theme */
 [data-theme="dark"] {
     --zf-card-bg: #1e1e2e;
     --zf-border: #334155;
@@ -38,7 +36,7 @@
     --zf-text-muted: #94a3b8;
 }
 
-/* Base Styles */
+/* === Base === */
 body {
     margin: 0;
     padding: 0;
@@ -46,8 +44,132 @@ body {
     color: var(--zf-text);
     background: var(--zf-bg);
     line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
 }
 
-#root {
-    min-height: 100%;
+/* === Shared Components === */
+
+.zf-card {
+    border: 1px solid var(--zf-border);
+    border-radius: 0.875rem;
+    padding: 1.25rem;
+    background: var(--zf-card-bg);
+    box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.04), 0 1px 2px -1px rgb(0 0 0 / 0.04);
+}
+
+.zf-badge {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    padding: 0.25rem 0.625rem;
+    border-radius: 9999px;
+    letter-spacing: 0.01em;
+}
+
+.zf-badge--success {
+    background: #dcfce7;
+    color: #15803d;
+}
+
+.zf-badge--warning {
+    background: #ffedd5;
+    color: #c2410c;
+}
+
+.zf-badge--info {
+    background: #dbeafe;
+    color: #1d4ed8;
+}
+
+[data-theme="dark"] .zf-badge--success {
+    background: rgb(21 128 61 / 0.2);
+    color: #4ade80;
+}
+
+[data-theme="dark"] .zf-badge--warning {
+    background: rgb(194 65 12 / 0.2);
+    color: #fb923c;
+}
+
+[data-theme="dark"] .zf-badge--info {
+    background: rgb(29 78 216 / 0.2);
+    color: #60a5fa;
+}
+
+.zf-cta {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.375rem;
+    width: 100%;
+    padding: 0.625rem 1rem;
+    border-radius: 0.625rem;
+    background: var(--zf-primary);
+    color: white;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background 150ms ease, transform 100ms ease;
+}
+
+.zf-cta:hover {
+    background: var(--zf-primary-light);
+    transform: translateY(-1px);
+}
+
+.zf-cta:active {
+    transform: translateY(0);
+}
+
+.zf-disclaimer {
+    font-size: 0.6875rem;
+    color: var(--zf-text-muted);
+    text-align: center;
+    margin-top: 0.75rem;
+}
+
+.zf-rule-tag {
+    font-size: 0.625rem;
+    padding: 0.125rem 0.5rem;
+    border-radius: 9999px;
+    background: #f1f5f9;
+    color: #475569;
+    font-weight: 500;
+    white-space: nowrap;
+}
+
+[data-theme="dark"] .zf-rule-tag {
+    background: #1e293b;
+    color: #94a3b8;
+}
+
+/* === Animations === */
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+    }
+
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes slideUp {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.animate-fade-in {
+    animation: fadeIn 400ms ease-out both;
+}
+
+.animate-slide-up {
+    animation: slideUp 350ms ease-out both;
 }

--- a/apps/chatgpt-widget/src/types.ts
+++ b/apps/chatgpt-widget/src/types.ts
@@ -46,3 +46,19 @@ export interface ComparisonResult {
     type: 'comparison';
     comparisons: MethodologyEntry[];
 }
+
+/** Individual asset added during an interactive session */
+export interface SessionAsset {
+    type: 'cash' | 'gold' | 'silver' | 'stocks' | 'retirement' | 'loans';
+    amount: number;
+}
+
+/** Progress state for an interactive calculation session */
+export interface SessionProgress {
+    type: 'session_progress';
+    sessionId: string;
+    assets: SessionAsset[];
+    runningZakat?: number;
+    methodology: string;
+    nextHint?: string;
+}


### PR DESCRIPTION
## Summary
Closes #29 (Parent: #24) — Completes Phase 2: Widget UI

### 3 Polished Widget Components

| Component | Key Features |
|-----------|-------------|
| **ZakatResultCard** | Gradient hero amount, nisab progress bar, staggered breakdown, arrow CTA |
| **MethodologyComparisonCard** | Range summary (min→max), "Lowest" badge, relative bars, rule tags |
| **SessionProgressCard** (NEW) | Asset icons, 5-step progress dots, running totals, next-step hints |

### Supporting Changes
- `App.tsx`: Fixed ext-apps API (`onAppCreated` → `app.ontoolresult`), session routing
- `index.css`: Shared design system (`.zf-card`, `.zf-badge`, `.zf-cta`, `.zf-rule-tag`), fadeIn/slideUp keyframes
- `types.ts`: Added `SessionProgress` + `SessionAsset` interfaces

### Verification
- [x] 21/21 widget tests passed (1.05s)
- [x] All 3 components importable and typed correctly
- [x] SessionProgress type contracts validated