### PR TITLE
docs: add README + technical design doc for ChatGPT Apps SDK integration

### DIFF
--- a/apps/chatgpt-widget/README.md
+++ b/apps/chatgpt-widget/README.md
@@ -1,0 +1,139 @@
+# ZakatFlow ChatGPT Widget
+
+> **Rich interactive Zakat widgets for ChatGPT** — A React 18 application that renders beautifully inside ChatGPT conversations via the MCP Apps SDK.
+
+## Overview
+
+The ChatGPT Widget package renders interactive Zakat calculation results directly inside ChatGPT conversations. When a user asks ChatGPT to calculate their Zakat, the MCP server returns `structuredContent` that this widget renders as premium, animated cards — bringing ZakatFlow's clarity and precision into the AI conversation itself.
+
+### Widget Components
+
+| Widget | Purpose | Key Features |
+|--------|---------|-------------|
+| **ZakatResultCard** | Single calculation result | Gradient hero amount, nisab progress bar, staggered breakdown, deep-link CTA |
+| **MethodologyComparisonCard** | Side-by-side comparison | Range summary, "Lowest" badge, relative bar charts, key rule tags |
+| **SessionProgressCard** | Interactive session tracker | Asset icons, 5-step progress dots, running totals, next-step hints |
+
+---
+
+## Technology Stack
+
+| Technology | Version | Purpose |
+|-----------|---------|---------|
+| React | 18.3 | Component framework |
+| Vite | 6.0 | Build tool with single-file output |
+| Tailwind CSS | 4.0 | Utility-first styling |
+| `@modelcontextprotocol/ext-apps` | 1.0 | MCP Apps bridge (`useApp` hook) |
+| `@openai/apps-sdk-ui` | 0.2 | ChatGPT design system |
+
+---
+
+## Architecture
+
+```
+apps/chatgpt-widget/
+├── index.html                          # Vite entry point
+├── vite.config.ts                      # Single-file output for MCP embedding
+├── src/
+│   ├── main.tsx                        # React root
+│   ├── App.tsx                         # MCP bridge + routing
+│   ├── index.css                       # Design system + animations
+│   ├── types.ts                        # Shared TypeScript interfaces
+│   ├── components/
+│   │   ├── ZakatResultCard.tsx         # Calculation result card
+│   │   ├── MethodologyComparisonCard.tsx # Comparison card
+│   │   └── SessionProgressCard.tsx     # Session progress card
+│   └── __tests__/
+│       └── widget.test.ts             # 21 type + component tests
+```
+
+### MCP Bridge Flow
+
+```
+ChatGPT → MCP Server → structuredContent → PostMessage → App.tsx → Widget Card
+```
+
+1. User asks ChatGPT to calculate Zakat
+2. MCP server runs `calculate_zakat` tool and returns `structuredContent`
+3. ChatGPT hosts the widget in an iframe, sends data via `PostMessageTransport`
+4. `App.tsx` receives data via `app.ontoolresult` callback
+5. Routes to the correct card based on data shape (`zakatDue` → Result, `type: comparison` → Comparison, `type: session_progress` → Progress)
+
+---
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js ≥ 18
+- npm ≥ 9
+
+### Installation
+
+```bash
+# From the monorepo root
+npm install --workspace=apps/chatgpt-widget
+```
+
+### Development
+
+```bash
+# Start Vite dev server
+npm run dev --workspace=apps/chatgpt-widget
+```
+
+### Build
+
+```bash
+# Production build (single-file output for MCP resource embedding)
+npm run build --workspace=apps/chatgpt-widget
+```
+
+The build outputs to `dist/` with a high asset inline limit (100KB), producing a self-contained HTML file suitable for serving as an MCP resource.
+
+---
+
+## Design System
+
+The widget uses CSS custom properties for seamless ChatGPT theme integration:
+
+| Token | Light | Dark | Purpose |
+|-------|-------|------|---------|
+| `--zf-text` | `#1a1a2e` | `#f1f5f9` | Primary text |
+| `--zf-text-muted` | `#64748b` | `#94a3b8` | Secondary text |
+| `--zf-card-bg` | `#ffffff` | `#1e1e2e` | Card background |
+| `--zf-border` | `#e2e8f0` | `#334155` | Border color |
+| `--zf-primary` | `#1a1a2e` | — | CTA button |
+| `--zf-accent` | `#16a34a` | — | Brand green |
+
+### Shared CSS Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.zf-card` | Card container with border, radius, shadow |
+| `.zf-badge` | Rounded pill badge (variants: `--success`, `--warning`, `--info`) |
+| `.zf-cta` | Primary CTA button with hover lift |
+| `.zf-rule-tag` | Small pill tag for key rules |
+| `.zf-disclaimer` | Scholarly disclaimer text |
+| `.animate-fade-in` | 400ms fade-in animation |
+| `.animate-slide-up` | 350ms slide-up with stagger support |
+
+---
+
+## Testing
+
+```bash
+# Run widget tests
+npm test --workspace=apps/chatgpt-widget
+
+# Watch mode
+npm run test:watch --workspace=apps/chatgpt-widget
+```
+
+**Test coverage:** 21 tests — type contracts for all 3 data shapes + component existence verification.
+
+---
+
+## License
+
+[AGPL-3.0-or-later](../../LICENSE) — © 2026 ZakatFlow

--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -1,0 +1,148 @@
+# ZakatFlow MCP Server
+
+> **The AI backbone for ZakatFlow** — An MCP (Model Context Protocol) server that enables conversational Zakat calculation through ChatGPT, Claude, and other AI assistants.
+
+## Overview
+
+The ZakatFlow MCP Server exposes Islamic finance calculation tools via the [Model Context Protocol](https://modelcontextprotocol.io), allowing AI assistants to compute Zakat obligations using eight scholarly methodologies. It handles user identity persistence, encrypted session storage, and interactive widget rendering — all while respecting Islamic jurisprudence (fiqh) precision.
+
+### Key Capabilities
+
+| Capability | Description |
+|-----------|-------------|
+| **8 Methodologies** | Bradford, Hanafi, Shafii, Maliki, Hanbali, AMJA, Qaradawi, and Yusuf al-Qaradawi approaches |
+| **Encrypted Sessions** | AES-256-GCM encryption with scrypt KDF for session data at rest |
+| **ChatGPT Identity** | Persistent user profiles linked via OpenAI Apps SDK context |
+| **Interactive Widgets** | Rich UI cards rendered inside ChatGPT via MCP Apps bridge |
+| **Scholarly Disclaimer** | Every response includes fiqh-appropriate "calculations, not fatwas" guidance |
+
+---
+
+## Architecture
+
+```
+apps/mcp-server/
+├── src/
+│   ├── index.ts                  # Server bootstrap + tool registration
+│   ├── stdio.ts                  # MCP stdio transport
+│   ├── crypto.ts                 # AES-256-GCM encryption (Privacy Vault)
+│   ├── supabase.ts               # Dual-client: anon + service-role
+│   ├── identity/
+│   │   └── chatgpt.ts            # ChatGPT user CRUD + session writes
+│   ├── session/
+│   │   └── persistent-store.ts   # In-memory cache + encrypted Supabase persistence
+│   ├── tools/
+│   │   ├── calculate_zakat.ts    # Primary calculation tool
+│   │   ├── compare_madhabs.ts    # Multi-methodology comparison
+│   │   └── ...                   # Additional MCP tools
+│   ├── widget/
+│   │   └── template.ts           # Widget URI + MIME registration
+│   └── __tests__/
+│       ├── tools.test.ts         # 17 tool tests
+│       ├── identity.test.ts      # 11 identity tests
+│       └── crypto.test.ts        # 21 crypto + session tests
+```
+
+---
+
+## Getting Started
+
+### Prerequisites
+
+- **Node.js** ≥ 18
+- **npm** ≥ 9 (workspace-aware)
+- A [Supabase](https://supabase.com) project (optional — server degrades gracefully without it)
+
+### Installation
+
+```bash
+# From the monorepo root
+npm install
+
+# Or install just this workspace
+npm install --workspace=apps/mcp-server
+```
+
+### Environment Variables
+
+Copy the example file and fill in your credentials:
+
+```bash
+cp apps/mcp-server/.env.example apps/mcp-server/.env.local
+```
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `SUPABASE_URL` | Optional | Supabase project URL |
+| `SUPABASE_ANON_KEY` | Optional | Publishable anon key (respects RLS) |
+| `SUPABASE_SERVICE_KEY` | Optional | Service role key (**never expose publicly**) |
+| `ENCRYPTION_MASTER_KEY` | Optional | 64-char hex string for AES-256-GCM encryption |
+| `NODE_ENV` | Optional | `development` or `production` |
+| `CLIENT_URL` | Optional | ZakatFlow web app URL for deep-links |
+
+> **Generate an encryption key:**
+> ```bash
+> node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+> ```
+
+### Running
+
+```bash
+# Development (watch mode)
+npm run dev --workspace=apps/mcp-server
+
+# Connect via MCP Inspector
+npx @modelcontextprotocol/inspector node dist/index.js
+```
+
+---
+
+## MCP Tools
+
+### `calculate_zakat`
+
+Computes Zakat obligation for a given set of financial inputs. Returns both narrated text (for the AI to summarize) and `structuredContent` (for the widget to render).
+
+**Inputs:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `cash` | `number` | Cash, checking, and savings (required) |
+| `gold_value` | `number?` | Value of gold in USD |
+| `silver_value` | `number?` | Value of silver in USD |
+| `long_term_investments` | `number?` | Passive stocks/funds (subject to methodology-specific rates) |
+| `retirement_total` | `number?` | 401(k)/IRA vested balance |
+| `loans` | `number?` | Immediate debts due now |
+| `madhab` | `string?` | Methodology: `bradford`, `hanafi`, `shafii`, `maliki`, `hanbali`, `amja`, `qaradawi` |
+
+### `compare_madhabs`
+
+Runs the same financial data through multiple methodologies and returns a side-by-side comparison with key rule differences (passive investment rates, liability methods, nisab standards).
+
+---
+
+## Testing
+
+```bash
+# Run all MCP server tests
+npm test --workspace=apps/mcp-server
+
+# Watch mode
+npm run test:watch --workspace=apps/mcp-server
+```
+
+**Test coverage:** 49 tests across 3 suites (tools, identity, crypto) — runs in ~1 second.
+
+---
+
+## Security
+
+- **Encryption:** AES-256-GCM with scrypt key derivation (N=16384, r=8, p=1). Unique salt + IV per encryption — ciphertext is never reused.
+- **RLS:** Supabase Row Level Security enabled with zero public policies on `chatgpt_users` and `chatgpt_sessions` tables. The anon key cannot read ChatGPT data.
+- **Graceful Degradation:** All features degrade gracefully when Supabase or encryption is unconfigured. The server never crashes due to missing credentials.
+
+---
+
+## License
+
+[AGPL-3.0-or-later](../../LICENSE) — © 2026 ZakatFlow

--- a/docs/chatgpt-apps-sdk-design.md
+++ b/docs/chatgpt-apps-sdk-design.md
@@ -1,0 +1,239 @@
+# Technical Design: ChatGPT Apps SDK Integration
+
+> **Author:** Senior Tech Lead  
+> **Status:** Implemented (PRs #30–#35 merged)  
+> **Parent Issue:** [#24](https://github.com/naheed/zakah/issues/24)
+
+---
+
+## 1. Problem Statement
+
+ZakatFlow's existing MCP server provides text-only tool responses to AI assistants. Users asking ChatGPT to calculate their Zakat receive a wall of plain text — no visual breakdown, no methodology comparison, no persistent sessions. This limits engagement and makes it difficult to convey the nuance of different scholarly approaches.
+
+### Goals
+
+1. Render interactive UI widgets inside ChatGPT conversations
+2. Persist user identity and session data across conversations
+3. Encrypt sensitive financial data at rest
+4. Maintain backward compatibility with existing text-mode MCP clients
+
+---
+
+## 2. Architecture
+
+### System Context
+
+```mermaid
+graph TB
+    User["User in ChatGPT"] --> ChatGPT
+    ChatGPT -->|"MCP Protocol"| MCP["ZakatFlow MCP Server"]
+    MCP -->|"structuredContent"| Bridge["MCP Apps Bridge"]
+    Bridge -->|"PostMessage"| Widget["chatgpt-widget (iframe)"]
+    MCP -->|"Service Role"| Supabase["Supabase (PostgreSQL)"]
+    MCP -->|"@zakatflow/core"| Engine["ZMCS Calculation Engine"]
+    Widget -->|"Deep Link"| Web["zakatflow.org"]
+```
+
+### Package Boundaries
+
+| Package | Responsibility | Dependencies |
+|---------|---------------|--------------|
+| `packages/core` | ZMCS calculation engine, 8 methodology presets | Zero runtime deps |
+| `apps/mcp-server` | MCP tools, identity, encryption, session store | `@zakatflow/core`, `@modelcontextprotocol/sdk`, `@supabase/supabase-js` |
+| `apps/chatgpt-widget` | React widget cards rendered in ChatGPT | `@modelcontextprotocol/ext-apps/react`, `@openai/apps-sdk-ui` |
+| `apps/web` | Main web application (unmodified by this work) | — |
+
+### Data Flow
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant C as ChatGPT
+    participant M as MCP Server
+    participant S as Supabase
+    participant W as Widget
+
+    U->>C: "Calculate my Zakat: $10K cash, $5K stocks"
+    C->>M: calculate_zakat(cash=10000, long_term=5000)
+    M->>M: @zakatflow/core.calculateZakat()
+    M->>S: saveSession(encrypted)
+    M-->>C: { content: [...], structuredContent: {...} }
+    C->>W: PostMessage(structuredContent)
+    W->>W: Render ZakatResultCard
+    U->>W: Click "View Full Report"
+    W->>U: Redirect to zakatflow.org?data=...
+```
+
+---
+
+## 3. Key Design Decisions
+
+### 3.1 Dual Supabase Client Pattern
+
+**Decision:** Two separate Supabase clients with different permission levels.
+
+| Client | Key Type | Use Case | Risk Profile |
+|--------|----------|----------|-------------|
+| `getSupabase()` | Anon (publishable) | Public data reads | Low — RLS enforced |
+| `getSupabaseAdmin()` | Service Role | ChatGPT identity writes | High — bypasses RLS |
+
+**Rationale:** The MCP server is a trusted backend process, not a browser. Using the service role key for ChatGPT-specific tables avoids needing to implement Supabase Auth for a non-browser context. RLS still protects the anon key from accessing ChatGPT tables (zero public policies).
+
+### 3.2 Envelope Encryption (Privacy Vault)
+
+**Decision:** Server-side AES-256-GCM with scrypt key derivation.
+
+```
+ENCRYPTION_MASTER_KEY (env var, 256 bits)
+    → scrypt(master_key, random_salt) → DEK
+        → AES-256-GCM(DEK, random_IV, plaintext) → ciphertext
+
+Envelope: [salt:16][iv:12][authTag:16][ciphertext:N]
+Serialized: "enc:v1:" + base64(envelope)
+```
+
+**Key properties:**
+- Unique salt + IV per encryption (never reused)
+- scrypt parameters: N=16384, r=8, p=1 (OWASP recommended)
+- GCM authentication tag prevents tampering
+- Plaintext fallback when `ENCRYPTION_MASTER_KEY` is unset
+- Plain JSON is automatically detected and deserialized on decrypt
+
+**Alternative considered:** Using the web app's `jose` JWE library. Rejected because the MCP server runs in Node.js where `crypto.createCipheriv` is native and avoids the `jose` dependency.
+
+### 3.3 Isolated Widget Package
+
+**Decision:** Separate `apps/chatgpt-widget` package instead of adding to `apps/web`.
+
+**Rationale:**
+- `apps/web` uses Tailwind CSS 3 (via `@shadcn/ui`); the widget needs Tailwind 4 for `@openai/apps-sdk-ui` compatibility
+- Widget must build to a single self-contained HTML file for MCP resource embedding
+- Different deployment target (served by MCP server, not Vercel/Lovable)
+- Independent test suite (jsdom environment, not Playwright)
+
+### 3.4 MCP Apps Bridge API
+
+**Decision:** Use `onAppCreated` callback with `app.ontoolresult` event handler.
+
+```tsx
+const { app } = useApp({
+    appInfo: { name: 'ZakatFlow', version: '0.2.0' },
+    capabilities: {},
+    onAppCreated: (app) => {
+        app.ontoolresult = (result) => {
+            // Route structuredContent to the correct widget
+        };
+    },
+});
+```
+
+**Routing logic:** Data shape discrimination, not tool name matching:
+- `data.zakatDue` (number) → `ZakatResultCard`
+- `data.type === 'comparison'` → `MethodologyComparisonCard`
+- `data.type === 'session_progress'` → `SessionProgressCard`
+
+This decouples the widget from specific tool names and makes it forward-compatible with new tools.
+
+---
+
+## 4. Database Schema
+
+### Tables (service-role access only)
+
+```sql
+CREATE TABLE chatgpt_users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    chatgpt_user_id TEXT UNIQUE NOT NULL,
+    display_name TEXT,
+    preferred_madhab TEXT DEFAULT 'bradford',
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE chatgpt_sessions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID REFERENCES chatgpt_users(id) ON DELETE CASCADE,
+    session_data JSONB,          -- Encrypted envelope or plain JSON
+    methodology TEXT DEFAULT 'bradford',
+    created_at TIMESTAMPTZ DEFAULT now(),
+    updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+-- RLS: enabled, zero public policies
+ALTER TABLE chatgpt_users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE chatgpt_sessions ENABLE ROW LEVEL SECURITY;
+```
+
+### Indexes
+
+- `chatgpt_users.chatgpt_user_id` — UNIQUE, fast lookup by OpenAI user ID
+- `chatgpt_sessions.user_id` — FK, cascade delete
+
+---
+
+## 5. Security Model
+
+### Threat Boundaries
+
+| Threat | Mitigation |
+|--------|-----------|
+| Master key exposure | Environment variable only — never in code or version control |
+| Session data at rest | AES-256-GCM encryption before Supabase write |
+| Anon key accessing ChatGPT data | RLS with zero public policies on `chatgpt_*` tables |
+| Prompt injection via tool inputs | Zod schema validation on all tool parameters |
+| Ciphertext tampering | GCM authentication tag (128-bit) detects modification |
+| Key reuse | Unique random salt (128-bit) + IV (96-bit) per encryption |
+
+### Graceful Degradation
+
+| Missing Config | Behavior |
+|---------------|----------|
+| No `SUPABASE_URL` | Server runs without persistence — in-memory sessions only |
+| No `SUPABASE_SERVICE_KEY` | Admin client returns null — identity features disabled |
+| No `ENCRYPTION_MASTER_KEY` | Session data stored as plaintext JSON (logged warning) |
+| No `CLIENT_URL` | Deep-links default to `https://zakatflow.org` |
+
+---
+
+## 6. Testing Strategy
+
+### Scoped Testing (per `/orchestrate` workflow rules)
+
+| Package | Command | Tests | Duration |
+|---------|---------|-------|----------|
+| `apps/mcp-server` | `npm test --workspace=apps/mcp-server` | 49 | ~1.1s |
+| `apps/chatgpt-widget` | `npm test --workspace=apps/chatgpt-widget` | 21 | ~1.0s |
+| **Total** | — | **70** | **~2.1s** |
+
+### Test Categories
+
+| Category | What's Tested |
+|----------|--------------|
+| Tool correctness | `calculate_zakat` structuredContent shape, calculation accuracy across 8 madhabs |
+| Comparison logic | `compare_madhabs` multi-methodology output, key rule assertions |
+| Widget contract | URI protocol, MIME type, component exports |
+| Crypto round-trip | Encrypt → decrypt, tamper detection, wrong key rejection, large payloads |
+| Identity graceful fallback | All identity functions return null/empty when Supabase is unconfigured |
+| Type contracts | Widget TypeScript interfaces match MCP server structuredContent shapes |
+
+---
+
+## 7. Future Work (Phase 3)
+
+| Item | Description |
+|------|-------------|
+| Dockerfile | Multi-stage build: `npm ci` → `npm run build` → Node.js slim runtime |
+| Cloud Run | Serverless deployment with `ENCRYPTION_MASTER_KEY` in Secret Manager |
+| App Store submission | OpenAI App Store listing with widget preview screenshots |
+| `start_session` / `add_asset` tools | Interactive multi-turn MCP tools that emit `session_progress` structuredContent |
+| Widget hot-reload | Vite HMR proxy for local widget development inside ChatGPT |
+
+---
+
+## 8. References
+
+- [MCP Apps SDK Documentation](https://modelcontextprotocol.io/apps)
+- [OpenAI Apps SDK UI](https://www.npmjs.com/package/@openai/apps-sdk-ui)
+- [ext-apps React Hooks API](https://www.npmjs.com/package/@modelcontextprotocol/ext-apps)
+- [ZakatFlow ZMCS Engine](../packages/core/README.md)
+- [Privacy Vault Pattern](../apps/web/src/lib/sessionEncryption.ts)


### PR DESCRIPTION
## Summary
Adds comprehensive documentation for the ChatGPT Apps SDK integration (Issues #25–#29).

### New Files
| File | Author Persona | Content |
|------|---------------|---------|
| `apps/mcp-server/README.md` | PMM + Tech Lead | Architecture, MCP tools, env vars, security, testing |
| `apps/chatgpt-widget/README.md` | PMM + UI Engineer | Component showcase, design system tokens, MCP bridge flow |
| `docs/chatgpt-apps-sdk-design.md` | Senior Tech Lead | Full technical design with Mermaid diagrams, ADRs, schema, security model |

### Highlights
- Mermaid sequence + flow diagrams for system context and data flow
- Design decision records: dual Supabase client, envelope encryption, isolated widget package
- Security threat model with mitigations
- Scoped testing strategy documentation