### PR TITLE
feat(mcp): record anonymized calculations in usage analytics

### DIFF
--- a/apps/mcp-server/src/__tests__/analytics.test.ts
+++ b/apps/mcp-server/src/__tests__/analytics.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2026 ZakatFlow
+ *
+ * AGPL-3.0-or-later
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { generateSessionHash, roundForPrivacy, getDefaultSessionId, recordAnonymousCalculation } from '../analytics.js';
+import { createHash } from 'node:crypto';
+
+// ---------------------------------------------------------------------------
+// Unit Tests — Pure Functions
+// ---------------------------------------------------------------------------
+
+describe('Analytics — generateSessionHash', () => {
+    it('returns a 64-char hex SHA-256 hash', () => {
+        const hash = generateSessionHash('test-session-id');
+        expect(hash).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('is deterministic for the same session ID on the same day', () => {
+        const hash1 = generateSessionHash('session-abc');
+        const hash2 = generateSessionHash('session-abc');
+        expect(hash1).toBe(hash2);
+    });
+
+    it('produces different hashes for different session IDs', () => {
+        const hash1 = generateSessionHash('session-1');
+        const hash2 = generateSessionHash('session-2');
+        expect(hash1).not.toBe(hash2);
+    });
+
+    it('includes date in the hash to ensure daily deduplication', () => {
+        // Verify the hash contains the date component
+        const today = new Date().toISOString().split('T')[0];
+        const expectedHash = createHash('sha256')
+            .update(`my-session:${today}`)
+            .digest('hex');
+        const actual = generateSessionHash('my-session');
+        expect(actual).toBe(expectedHash);
+    });
+});
+
+describe('Analytics — roundForPrivacy', () => {
+    it('rounds assets to nearest $1,000', () => {
+        expect(roundForPrivacy(12345, 1000)).toBe(12000);
+        expect(roundForPrivacy(12500, 1000)).toBe(13000);
+        expect(roundForPrivacy(12999, 1000)).toBe(13000);
+        expect(roundForPrivacy(0, 1000)).toBe(0);
+    });
+
+    it('rounds zakat to nearest $100', () => {
+        expect(roundForPrivacy(308.50, 100)).toBe(300);
+        expect(roundForPrivacy(350, 100)).toBe(400);
+        expect(roundForPrivacy(99.99, 100)).toBe(100);
+        expect(roundForPrivacy(0, 100)).toBe(0);
+    });
+
+    it('handles large values correctly', () => {
+        expect(roundForPrivacy(99_999_999, 1000)).toBe(100_000_000);
+        expect(roundForPrivacy(1_000_000_000, 1000)).toBe(1_000_000_000);
+    });
+});
+
+describe('Analytics — getDefaultSessionId', () => {
+    it('returns a string', () => {
+        const id = getDefaultSessionId();
+        expect(typeof id).toBe('string');
+        expect(id.length).toBeGreaterThan(0);
+    });
+
+    it('returns the same ID on repeated calls (singleton)', () => {
+        const id1 = getDefaultSessionId();
+        const id2 = getDefaultSessionId();
+        expect(id1).toBe(id2);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Integration Tests — recordAnonymousCalculation
+// ---------------------------------------------------------------------------
+
+describe('Analytics — recordAnonymousCalculation', () => {
+    it('returns silently when Supabase is not configured', async () => {
+        // Without SUPABASE env vars, getSupabaseAdmin() returns null
+        // recordAnonymousCalculation should just return without error
+        await expect(
+            recordAnonymousCalculation('test-session', 10000, 250)
+        ).resolves.toBeUndefined();
+    });
+
+    it('returns silently for negative totalAssets', async () => {
+        await expect(
+            recordAnonymousCalculation('test-session', -100, 0)
+        ).resolves.toBeUndefined();
+    });
+
+    it('returns silently for negative zakatDue', async () => {
+        await expect(
+            recordAnonymousCalculation('test-session', 10000, -50)
+        ).resolves.toBeUndefined();
+    });
+
+    it('returns silently when zakatDue exceeds totalAssets', async () => {
+        await expect(
+            recordAnonymousCalculation('test-session', 1000, 2000)
+        ).resolves.toBeUndefined();
+    });
+
+    it('returns silently for values exceeding maximum thresholds', async () => {
+        await expect(
+            recordAnonymousCalculation('test-session', 200_000_000_000, 250)
+        ).resolves.toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Migration Validation
+// ---------------------------------------------------------------------------
+
+describe('Analytics — SQL Migration', () => {
+    it('migration file exists', async () => {
+        const fs = await import('node:fs');
+        const path = await import('node:path');
+        const migrationPath = path.resolve(
+            import.meta.dirname || '.',
+            '../../../web/supabase/migrations/20260222000000_analytics_source_column.sql'
+        );
+        const exists = fs.existsSync(migrationPath);
+        expect(exists).toBe(true);
+    });
+
+    it('migration adds source column with web default', async () => {
+        const fs = await import('node:fs');
+        const path = await import('node:path');
+        const migrationPath = path.resolve(
+            import.meta.dirname || '.',
+            '../../../web/supabase/migrations/20260222000000_analytics_source_column.sql'
+        );
+        const content = fs.readFileSync(migrationPath, 'utf-8');
+        expect(content).toContain('source');
+        expect(content).toContain("DEFAULT 'web'");
+        expect(content).toContain('zakat_anonymous_events');
+    });
+});

--- a/apps/mcp-server/src/analytics.ts
+++ b/apps/mcp-server/src/analytics.ts
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2026 ZakatFlow
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+/**
+ * Anonymized calculation analytics — server-side equivalent of the
+ * `track-zakat-calculation` Supabase Edge Function.
+ *
+ * Privacy guarantees (identical to the web app):
+ *   1. Session hash: SHA-256 of sessionId + date (no PII)
+ *   2. Values rounded: assets → nearest $1,000, zakat → nearest $100
+ *   3. Deduplication: UNIQUE(session_hash, event_date) prevents double-counting
+ *   4. Service role writes only (no public RLS policies)
+ *   5. Fire-and-forget: errors are logged, never block the user
+ */
+
+import { createHash, randomUUID } from 'node:crypto';
+import { getSupabaseAdmin } from './supabase.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+const MAX_TOTAL_ASSETS = 100_000_000_000;  // $100 billion
+const MAX_ZAKAT_DUE = 10_000_000_000;      // $10 billion
+const SOURCE = 'chatgpt';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a SHA-256 session hash for deduplication.
+ * Uses sessionId + date to ensure one event per session per day.
+ */
+export function generateSessionHash(sessionId: string): string {
+    const today = new Date().toISOString().split('T')[0];
+    return createHash('sha256')
+        .update(`${sessionId}:${today}`)
+        .digest('hex');
+}
+
+/**
+ * Round a value for additional privacy.
+ *   - Assets → nearest $1,000
+ *   - Zakat  → nearest $100
+ */
+export function roundForPrivacy(value: number, granularity: number): number {
+    return Math.round(value / granularity) * granularity;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Record an anonymized calculation event.
+ *
+ * This is a fire-and-forget function — call it with `.catch(() => {})`
+ * so analytics never blocks the user's Zakat calculation response.
+ *
+ * @param sessionId - Unique session identifier (UUID or any string)
+ * @param totalAssets - Total zakatable assets (unrounded)
+ * @param zakatDue - Zakat due amount (unrounded)
+ */
+export async function recordAnonymousCalculation(
+    sessionId: string,
+    totalAssets: number,
+    zakatDue: number
+): Promise<void> {
+    const supabase = getSupabaseAdmin();
+    if (!supabase) return; // Graceful fallback: no Supabase = no analytics
+
+    // Validate
+    if (totalAssets < 0 || totalAssets > MAX_TOTAL_ASSETS) return;
+    if (zakatDue < 0 || zakatDue > MAX_ZAKAT_DUE) return;
+    if (zakatDue > totalAssets) return;
+
+    // Privacy: round values
+    const roundedAssets = roundForPrivacy(totalAssets, 1000);
+    const roundedZakat = roundForPrivacy(zakatDue, 100);
+
+    // Generate deduplication hash
+    const sessionHash = generateSessionHash(sessionId);
+    const today = new Date().toISOString().split('T')[0];
+
+    try {
+        // Insert event (deduplicated by session_hash + event_date)
+        const { data: insertData, error: insertError } = await supabase
+            .from('zakat_anonymous_events')
+            .upsert(
+                {
+                    session_hash: sessionHash,
+                    event_date: today,
+                    total_assets: roundedAssets,
+                    zakat_due: roundedZakat,
+                    source: SOURCE,
+                },
+                { onConflict: 'session_hash,event_date', ignoreDuplicates: true }
+            )
+            .select();
+
+        if (insertError) {
+            console.error('[Analytics] Error inserting event:', insertError.message);
+            return;
+        }
+
+        // Only update aggregates for new events (not duplicates)
+        const isNewEvent = insertData && insertData.length > 0;
+        if (!isNewEvent) return;
+
+        // Update aggregate periods
+        const currentMonth = today.substring(0, 7); // YYYY-MM
+        const currentYear = today.substring(0, 4);   // YYYY
+
+        const periods = [
+            { period_type: 'monthly', period_value: currentMonth },
+            { period_type: 'yearly', period_value: currentYear },
+            { period_type: 'all_time', period_value: 'all' },
+        ];
+
+        for (const period of periods) {
+            const { error: rpcError } = await supabase.rpc('increment_usage_aggregate', {
+                p_period_type: period.period_type,
+                p_period_value: period.period_value,
+                p_assets: roundedAssets,
+                p_zakat: roundedZakat,
+            });
+
+            if (rpcError) {
+                console.error(`[Analytics] Error updating ${period.period_type} aggregate:`, rpcError.message);
+                // Fallback: try direct update
+                const { data: existing } = await supabase
+                    .from('zakat_usage_aggregates')
+                    .select('*')
+                    .eq('period_type', period.period_type)
+                    .eq('period_value', period.period_value)
+                    .single();
+
+                if (existing) {
+                    await supabase
+                        .from('zakat_usage_aggregates')
+                        .update({
+                            unique_sessions: existing.unique_sessions + 1,
+                            total_assets: existing.total_assets + roundedAssets,
+                            total_zakat: existing.total_zakat + roundedZakat,
+                            calculation_count: existing.calculation_count + 1,
+                            updated_at: new Date().toISOString(),
+                        })
+                        .eq('period_type', period.period_type)
+                        .eq('period_value', period.period_value);
+                } else {
+                    await supabase.from('zakat_usage_aggregates').insert({
+                        period_type: period.period_type,
+                        period_value: period.period_value,
+                        unique_sessions: 1,
+                        total_assets: roundedAssets,
+                        total_zakat: roundedZakat,
+                        calculation_count: 1,
+                    });
+                }
+            }
+        }
+
+        console.log('[Analytics] Recorded ChatGPT calculation event');
+    } catch (e) {
+        console.error('[Analytics] Unexpected error:', (e as Error).message);
+    }
+}
+
+/**
+ * Generate a deterministic session ID for calculations without an explicit session.
+ * Uses a random UUID — one per process lifecycle.
+ */
+let _defaultSessionId: string | null = null;
+export function getDefaultSessionId(): string {
+    if (!_defaultSessionId) {
+        _defaultSessionId = randomUUID();
+    }
+    return _defaultSessionId;
+}

--- a/apps/mcp-server/src/tools/calculate_zakat.ts
+++ b/apps/mcp-server/src/tools/calculate_zakat.ts
@@ -20,6 +20,7 @@ import { registerAppTool } from "@modelcontextprotocol/ext-apps/server";
 import { z } from "zod";
 import { calculateZakat, ZakatFormData, defaultFormData, ZAKAT_PRESETS } from "@zakatflow/core";
 import { WIDGET_URI } from "../widget/template.js";
+import { recordAnonymousCalculation, getDefaultSessionId } from "../analytics.js";
 
 export function registerCalculateZakat(server: McpServer) {
     registerAppTool(
@@ -93,6 +94,9 @@ export function registerCalculateZakat(server: McpServer) {
                 methodologyId: selectedMadhab,
                 reportLink,
             };
+
+            // Record anonymized event (fire-and-forget, never blocks response)
+            recordAnonymousCalculation(getDefaultSessionId(), result.totalAssets, result.zakatDue).catch(() => { });
 
             return {
                 content: [

--- a/apps/mcp-server/src/tools/compare_madhabs.ts
+++ b/apps/mcp-server/src/tools/compare_madhabs.ts
@@ -26,6 +26,7 @@ import {
     AVAILABLE_PRESETS,
 } from "@zakatflow/core";
 import { WIDGET_URI } from "../widget/template.js";
+import { recordAnonymousCalculation, getDefaultSessionId } from "../analytics.js";
 
 const MADHAB_IDS = ['bradford', 'hanafi', 'shafii', 'maliki', 'hanbali', 'amja', 'qaradawi', 'tahir_anwar'] as const;
 
@@ -102,6 +103,12 @@ export function registerCompareMadhabs(server: McpServer) {
   Investment Rate: ${((c.keyRules?.passiveInvestmentRate ?? 1) * 100)}%
   Liability Method: ${c.keyRules?.liabilityMethod}`;
             });
+
+            // Record anonymized event using first valid result (fire-and-forget)
+            const firstValid = comparisons.find(c => !('error' in c && c.error) && c.totalAssets !== undefined);
+            if (firstValid && firstValid.totalAssets !== undefined && firstValid.zakatDue !== undefined) {
+                recordAnonymousCalculation(getDefaultSessionId(), firstValid.totalAssets, firstValid.zakatDue).catch(() => { });
+            }
 
             return {
                 content: [

--- a/apps/web/supabase/migrations/20260222000000_analytics_source_column.sql
+++ b/apps/web/supabase/migrations/20260222000000_analytics_source_column.sql
@@ -1,0 +1,9 @@
+-- Add source column to distinguish web vs ChatGPT calculation events
+-- Non-breaking: defaults to 'web' so existing rows are unaffected.
+
+ALTER TABLE public.zakat_anonymous_events
+ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'web';
+
+-- Index for filtering by source in analytics queries
+CREATE INDEX IF NOT EXISTS idx_anonymous_events_source
+ON public.zakat_anonymous_events (source);


### PR DESCRIPTION
## Summary
Closes #37 (Parent: #24)

MCP/ChatGPT calculations are now recorded in the same anonymized analytics tables as the web app, using identical privacy guarantees.

### Privacy Pattern (same as web)
| Guarantee | Implementation |
|-----------|---------------|
| No PII | SHA-256 session hash |
| Value obfuscation | Assets → $1K, Zakat → $100 |
| Deduplication | `UNIQUE(session_hash, event_date)` |
| Source tracking | `source = 'chatgpt'` column |
| Fire-and-forget | `.catch(() => {})` — never blocks response |
| Graceful fallback | Returns silently without Supabase |

### Files Changed
| File | Change |
|------|--------|
| `apps/mcp-server/src/analytics.ts` | NEW — analytics service |
| `apps/mcp-server/src/tools/calculate_zakat.ts` | +2 lines (import + fire-and-forget call) |
| `apps/mcp-server/src/tools/compare_madhabs.ts` | +6 lines (import + first-valid-result call) |
| `supabase/migrations/20260222000000_analytics_source_column.sql` | NEW — adds source column |
| `apps/mcp-server/src/__tests__/analytics.test.ts` | NEW — 16 tests |

### Verification
- [x] 65/65 MCP server tests passed (1.46s)
- [x] 16 new analytics tests (hash, rounding, fallback, validation, migration)
- [x] Existing 49 tests unchanged and green