### PR TITLE
feat(legal): add MCP/ChatGPT sections to Privacy Policy and Terms of Service

### DIFF
--- a/apps/web/src/content/privacy.ts
+++ b/apps/web/src/content/privacy.ts
@@ -16,7 +16,7 @@
  */
 
 import { ElementType } from "react";
-import { Shield, Lock, Eye, Clock, Warning, UserCircle, FileText, Robot, LockKey, UsersThree, Gavel, Buildings, Prohibit, ArrowsClockwise, Eraser, Files, AddressBook } from "@phosphor-icons/react";
+import { Shield, Lock, Eye, Clock, Warning, UserCircle, FileText, Robot, LockKey, UsersThree, Gavel, Buildings, Prohibit, ArrowsClockwise, Eraser, Files, AddressBook, ChatCircleDots } from "@phosphor-icons/react";
 
 export interface HighlightItem {
     icon: ElementType;
@@ -56,6 +56,10 @@ export const privacyHighlights: HighlightItem[] = [
     {
         icon: Warning,
         text: "Uploaded documents are processed by AI and immediately discarded — only extracted values are kept"
+    },
+    {
+        icon: ChatCircleDots,
+        text: "ChatGPT calculations are processed in-memory and discarded — only anonymized, rounded totals are stored for aggregate metrics"
     }
 ];
 
@@ -165,6 +169,51 @@ export const privacySections: SectionContent[] = [
                     "Your raw documents are processed in ephemeral memory—they exist only for the seconds it takes to read them.",
                     "We never use your personal financial data to train public AI models."
                 ]
+            }
+        ]
+    },
+    {
+        id: "chatgpt",
+        title: "AI Assistant & MCP Server (ChatGPT Integration)",
+        content: `When you use ZakatFlow through ChatGPT or other AI assistants, your financial data is processed by our Model Context Protocol (MCP) server. This section describes how your data is handled in this context, including what we call the "privacy gap" — the distinction between data handled by OpenAI and data handled by ZakatFlow.`,
+        subsections: [
+            {
+                title: "4a.1 Data Flow",
+                content: "When ChatGPT calls ZakatFlow to calculate your Zakat, the following data flow occurs:",
+                listItems: [
+                    "Your financial inputs (asset values, liabilities) are sent from ChatGPT to our MCP server",
+                    "Our server computes your Zakat obligation in-memory using our calculation engine",
+                    "The calculation result is returned to ChatGPT for display",
+                    "Your raw financial inputs are immediately discarded — they are NOT stored on our servers in any form"
+                ],
+                note: "Important: When ChatGPT sends your data to ZakatFlow, it leaves OpenAI's infrastructure. Our privacy protections (described below) apply, but OpenAI's privacy policies no longer govern this data. This is the 'privacy gap' you should be aware of."
+            },
+            {
+                title: "4a.2 What We Store",
+                content: "We store the following data from ChatGPT interactions:",
+                listItems: [
+                    "Anonymized Analytics: A cryptographic hash (SHA-256) of your session ID combined with the date — this cannot be reversed to identify you. Rounded asset totals (nearest $1,000) and Zakat amounts (nearest $100) for aggregate metrics only.",
+                    "ChatGPT User Identity: If provided by OpenAI, your ChatGPT user identifier may be stored to enable session continuity. This is an opaque ID that cannot identify you personally.",
+                    "Encrypted Session State: If you use multi-step calculations, your in-progress data is encrypted with AES-256-GCM before storage. We cannot read this data in plaintext."
+                ]
+            },
+            {
+                title: "4a.3 What We Do NOT Store or Do",
+                listItems: [
+                    "We do NOT store your raw financial inputs (cash, investments, debts, etc.) in plaintext",
+                    "We do NOT use your data to train any AI models",
+                    "We do NOT sell, share, or rent your data to third parties",
+                    "We do NOT track your IP address, browser, or device information from ChatGPT sessions",
+                    "We do NOT link ChatGPT calculations to any ZakatFlow web account"
+                ]
+            },
+            {
+                title: "4a.4 Session Data Deletion",
+                content: "You may request deletion of your ChatGPT session data at any time by contacting privacy@vora.dev with your ChatGPT user ID. Anonymized aggregate analytics (rounded totals) cannot be deleted as they contain no personally identifiable information."
+            },
+            {
+                title: "4a.5 Source Tracking",
+                content: "We tag analytics events with a 'source' field (e.g., 'web' or 'chatgpt') to understand how our calculator is used across platforms. This helps us improve the service but does not identify individual users."
             }
         ]
     },
@@ -313,7 +362,7 @@ export const privacySections: SectionContent[] = [
     {
         id: "children",
         title: "Children's Privacy",
-        content: "The Service is not intended for use by individuals under the age of 18. We do not knowingly collect personal information from children."
+        content: "The Service is not intended for use by individuals under the age of 13, consistent with OpenAI's age requirements for ChatGPT. Users under the age of 18 should use the Service only under the supervision of a parent or guardian, as Zakat calculations involve financial data that requires adult judgment. We do not knowingly collect personal information from children under 13."
     },
     {
         id: "changes",

--- a/apps/web/src/content/terms.ts
+++ b/apps/web/src/content/terms.ts
@@ -16,7 +16,7 @@
  */
 
 import { ElementType } from "react";
-import { Scroll, FileText, Warning, UserCircle, LockKey, Lightning, Shield, Scales, Handshake, Copyright, Prohibit, Gavel, Buildings, ArrowsClockwise, Eraser, Files, AddressBook } from "@phosphor-icons/react";
+import { Scroll, FileText, Warning, UserCircle, LockKey, Lightning, Shield, Scales, Handshake, Copyright, Prohibit, Gavel, Buildings, ArrowsClockwise, Eraser, Files, AddressBook, ChatCircleDots } from "@phosphor-icons/react";
 
 export interface TermSection {
     id: string;
@@ -60,7 +60,7 @@ export const termsSections: TermSection[] = [
         content: "We designed this Service to empower you with calculation tools and educational resources. However, Zakat is a deeply personal act of worship, and financial situations are unique. We recommend that you:",
         disclaimer: {
             strong: "Important:",
-            text: "Important: The Service does not provide financial, tax, legal, or religious advice. All calculations are for educational purposes only."
+            text: "Important: The Service does not provide financial, tax, legal, or religious advice. All calculations are provided for educational and informational purposes only. This applies whether you access ZakatFlow through our website, ChatGPT, or any other AI assistant."
         },
         listItems: [
             "Consult with qualified Islamic scholars for authoritative Zakat rulings",
@@ -120,8 +120,23 @@ export const termsSections: TermSection[] = [
         ]
     },
     {
-        id: "warranties",
+        id: "chatgpt",
         number: 8,
+        title: "ChatGPT AI Integration",
+        icon: ChatCircleDots,
+        content: "ZakatFlow is available as an integrated tool within ChatGPT and other AI assistants via the Model Context Protocol (MCP). By using ZakatFlow through these platforms:",
+        listItems: [
+            "Financial Disclaimer: ZakatFlow does not provide personalized financial advice, whether accessed through the web or AI assistants. The AI may help you gather and organize your financial information, but the calculation is performed by our engine using scholarly methodologies \u2014 not by AI judgment.",
+            "Multi-Methodology: ZakatFlow supports 8 scholarly methodologies. The inclusion of any methodology does not constitute an endorsement, recommendation, or fatwa. Users should follow the guidance of their trusted Islamic scholars.",
+            "Data Handling: Your financial inputs are processed in-memory and immediately discarded. Only anonymized, rounded analytics are stored. See our Privacy Policy (Section 4a) for complete details.",
+            "Age Restriction: The ChatGPT integration is subject to OpenAI's age requirements (13+). Users under 18 should use ZakatFlow under parental supervision.",
+            "Open Source: ZakatFlow's calculation engine and MCP server are open-source under AGPL v3. You may inspect the exact code that processes your data at github.com/naheed/zakah.",
+            "Third-Party Platforms: When you use ZakatFlow through ChatGPT, you are also subject to OpenAI's Terms of Use and Privacy Policy. ZakatFlow is not responsible for how OpenAI handles your data before it reaches or after it leaves our MCP server."
+        ]
+    },
+    {
+        id: "warranties",
+        number: 9,
         title: "Service Sustainability & Warranties",
         icon: Shield,
         content: "To provide this Service sustainably, we must limit our legal warranties. We build with care, but software is complex:",
@@ -134,7 +149,7 @@ export const termsSections: TermSection[] = [
     },
     {
         id: "liability",
-        number: 9,
+        number: 10,
         title: "Liability Limits",
         icon: Scales,
         content: "We encourage you to verify your results. To the maximum extent permitted by law, the Service and its creator shall not be liable for:",
@@ -147,76 +162,76 @@ export const termsSections: TermSection[] = [
     },
     {
         id: "indemnification",
-        number: 10,
+        number: 11,
         title: "Indemnification",
         icon: Handshake,
     },
     {
         id: "intellectual",
-        number: 11,
+        number: 12,
         title: "Intellectual Property",
         icon: Copyright,
         content: "The ZakatFlow code is open-source and licensed under the GNU Affero General Public License v3.0 (AGPL v3). You are free to inspect, modify, and redistribute the code under the terms of this license. However, the 'ZakatFlow' brand name, logo, and hosted service are proprietary."
     },
     {
         id: "termination",
-        number: 12,
+        number: 13,
         title: "Account Termination",
         icon: Prohibit,
         content: "We reserve the right to suspend or terminate your access to the Service at any time, without notice, for conduct that we believe violates these Terms or is harmful to other users or the Service."
     },
     {
         id: "disputes",
-        number: 13,
+        number: 14,
         title: "Dispute Resolution",
         icon: Gavel,
         content: "Any disputes arising from these Terms or your use of the Service shall be resolved through good faith negotiation. If negotiation fails, disputes shall be resolved through binding arbitration in accordance with the rules of the American Arbitration Association, conducted in California. You agree to waive any right to participate in a class action lawsuit or class-wide arbitration."
     },
     {
         id: "governing",
-        number: 14,
+        number: 15,
         title: "Governing Law",
         icon: Buildings,
         content: "These Terms shall be governed by and construed in accordance with the laws of the State of California, United States, without regard to its conflict of law provisions."
     },
     {
         id: "force-majeure",
-        number: 15,
+        number: 16,
         title: "Force Majeure",
         icon: Lightning,
         content: "We shall not be liable for any failure or delay in performing our obligations where such failure or delay results from circumstances beyond our reasonable control, including but not limited to natural disasters, acts of government, internet or infrastructure failures, or third-party service outages."
     },
     {
         id: "assignment",
-        number: 16,
+        number: 17,
         title: "Assignment",
         icon: ArrowsClockwise,
         content: "You may not assign or transfer these Terms or your rights hereunder without our prior written consent. We may assign these Terms without restriction."
     },
     {
         id: "changes",
-        number: 17,
+        number: 18,
         title: "Changes to Terms",
         icon: Eraser,
         content: "We reserve the right to modify these Terms at any time. We will notify you of material changes by posting the new Terms on this page and updating the \"Last updated\" date. Your continued use of the Service after changes constitutes acceptance of the new Terms."
     },
     {
         id: "severability",
-        number: 18,
+        number: 19,
         title: "Severability",
         icon: Files,
         content: "If any provision of these Terms is found to be unenforceable, the remaining provisions will continue in full force and effect."
     },
     {
         id: "entire",
-        number: 19,
+        number: 20,
         title: "Entire Agreement",
         icon: Scroll,
         content: "These Terms, together with our Privacy Policy, constitute the entire agreement between you and us regarding the Service and supersede all prior agreements and understandings."
     },
     {
         id: "contact",
-        number: 20,
+        number: 21,
         title: "Contact",
         icon: AddressBook,
         content: "For questions about these Terms, please contact:",


### PR DESCRIPTION
## Summary
Closes #41 (Parent: #24)

Adds ChatGPT/MCP-specific sections to existing legal pages for OpenAI App Directory submission.

### Privacy Policy (`privacy.ts`)
- **§4a AI Assistant & MCP Server** (5 subsections)
  - Data flow + "privacy gap" disclosure
  - What we store (anonymized analytics, encrypted sessions)
  - What we do NOT store/do (5 explicit negatives)
  - Session data deletion rights
  - Source tracking explanation
- ChatGPT privacy highlight badge
- Children's privacy updated: 13+ (OpenAI) with 18+ parental supervision

### Terms of Service (`terms.ts`)
- **§8 ChatGPT AI Integration** (6 provisions)
  - AI-specific financial disclaimer
  - Multi-methodology non-endorsement
  - Data handling cross-reference to Privacy §4a
  - Age restriction (13+ with parental supervision)
  - AGPL open-source notice
  - Third-party platform disclaimer
- Strengthened §3 financial disclaimer for AI context

### Verification
- [x] TypeScript compiles clean
- [x] 328/331 web tests pass (3 pre-existing PlaidMethod failures)