### PR TITLE
feat(mcp): add delete_my_data and view_legal self-service privacy tools

### DIFF
--- a/apps/mcp-server/src/index.ts
+++ b/apps/mcp-server/src/index.ts
@@ -27,6 +27,8 @@ import { registerMarketTools } from "./tools/market.js";
 import { registerDiscoveryTools } from "./tools/discovery.js";
 import { registerReportingTools } from "./tools/reporting.js";
 import { registerCompareMadhabs } from "./tools/compare_madhabs.js";
+import { registerDeleteData } from "./tools/delete_data.js";
+import { registerLegalTools } from "./tools/legal.js";
 import { registerWidgetTemplate } from "./widget/template.js";
 
 const app = express();
@@ -62,6 +64,8 @@ const handleMcpConnection = async (req: express.Request, res: express.Response) 
     registerDiscoveryTools(mcp);
     registerReportingTools(mcp);
     registerCompareMadhabs(mcp);
+    registerDeleteData(mcp);
+    registerLegalTools(mcp);
 
     const transport = new SSEServerTransport("/messages", res);
     const sessionId = transport.sessionId;

--- a/apps/mcp-server/src/tools/delete_data.ts
+++ b/apps/mcp-server/src/tools/delete_data.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2026 ZakatFlow
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import { getSupabaseAdmin } from "../supabase.js";
+
+export function registerDeleteData(server: McpServer) {
+    server.tool(
+        "delete_my_data",
+        "Permanently delete all your ZakatFlow data associated with your ChatGPT account. This removes your user record and all saved calculation sessions. Anonymized analytics (rounded totals with no identifying information) are retained as disclosed in our Privacy Policy §4a.3. This action is IRREVERSIBLE.",
+        {
+            chatgpt_user_id: z.string().describe("Your ChatGPT user ID (provided by OpenAI). Ask the user to confirm their identity before proceeding."),
+            confirm: z.boolean().describe("Must be true to execute deletion. Set to false to preview what would be deleted without actually deleting."),
+        },
+        async (params) => {
+            const { chatgpt_user_id, confirm } = params;
+
+            const supabase = getSupabaseAdmin();
+            if (!supabase) {
+                return {
+                    content: [{
+                        type: "text" as const,
+                        text: "Data deletion is not available at this time (database not configured). Please contact privacy@vora.dev for manual deletion."
+                    }]
+                };
+            }
+
+            // Look up user
+            const { data: user, error: findError } = await supabase
+                .from('chatgpt_users')
+                .select('id, chatgpt_user_id, created_at')
+                .eq('chatgpt_user_id', chatgpt_user_id)
+                .maybeSingle();
+
+            if (findError) {
+                return {
+                    content: [{
+                        type: "text" as const,
+                        text: `Error looking up your data: ${findError.message}. Please try again or contact privacy@vora.dev.`
+                    }]
+                };
+            }
+
+            if (!user) {
+                return {
+                    content: [{
+                        type: "text" as const,
+                        text: `No data found for ChatGPT user ID "${chatgpt_user_id}". You may not have any stored data with ZakatFlow, or the ID may be incorrect. No action was taken.`
+                    }]
+                };
+            }
+
+            // Count sessions for preview/summary
+            const { count: sessionCount } = await supabase
+                .from('chatgpt_sessions')
+                .select('*', { count: 'exact', head: true })
+                .eq('user_id', user.id);
+
+            const sessionsFound = sessionCount || 0;
+
+            // Preview mode — don't delete
+            if (!confirm) {
+                return {
+                    content: [{
+                        type: "text" as const,
+                        text: `📋 **Data Deletion Preview** (no data was deleted)\n\nFound the following data for your ChatGPT account:\n- **1 user record** (created ${user.created_at})\n- **${sessionsFound} calculation session(s)**\n\nTo proceed with permanent deletion, call this tool again with \`confirm: true\`.\n\n⚠️ This action is irreversible. Anonymized analytics (rounded totals) will be retained per our Privacy Policy §4a.3 as they contain no personally identifiable information.`
+                    }]
+                };
+            }
+
+            // Execute deletion — sessions first (FK dependency), then user
+            const { error: deleteSessionsError } = await supabase
+                .from('chatgpt_sessions')
+                .delete()
+                .eq('user_id', user.id);
+
+            if (deleteSessionsError) {
+                return {
+                    content: [{
+                        type: "text" as const,
+                        text: `Error deleting sessions: ${deleteSessionsError.message}. Please contact privacy@vora.dev for assistance.`
+                    }]
+                };
+            }
+
+            const { error: deleteUserError } = await supabase
+                .from('chatgpt_users')
+                .delete()
+                .eq('id', user.id);
+
+            if (deleteUserError) {
+                return {
+                    content: [{
+                        type: "text" as const,
+                        text: `Sessions deleted but error removing user record: ${deleteUserError.message}. Please contact privacy@vora.dev to complete the deletion.`
+                    }]
+                };
+            }
+
+            return {
+                content: [{
+                    type: "text" as const,
+                    text: `✅ **Data Deletion Complete**\n\nThe following data has been permanently deleted:\n- **1 user record** for ChatGPT user "${chatgpt_user_id}"\n- **${sessionsFound} calculation session(s)**\n\nAnonymized aggregate analytics (rounded asset/Zakat totals with no identifying information) are retained per our Privacy Policy §4a.3.\n\nIf you use ZakatFlow again through ChatGPT, a new user record will be created automatically.`
+                }]
+            };
+        }
+    );
+}

--- a/apps/mcp-server/src/tools/legal.ts
+++ b/apps/mcp-server/src/tools/legal.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2026 ZakatFlow
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+// ---------------------------------------------------------------------------
+// Privacy Policy Summary (ChatGPT-readable version of zakatflow.org/privacy)
+// ---------------------------------------------------------------------------
+const PRIVACY_SUMMARY = `# ZakatFlow Privacy Policy Summary
+**Full policy:** https://zakatflow.org/privacy
+
+## What We Collect
+- **Account Info**: Email, display name, profile picture (Google OAuth sign-in)
+- **Financial Data**: Asset values and liabilities you enter (encrypted before storage)
+- **Uploaded Documents**: Processed by AI in-memory, immediately discarded
+- **Usage Analytics**: Anonymized, aggregate statistics only
+
+## ChatGPT Integration (§4a)
+When you use ZakatFlow through ChatGPT:
+- Your financial inputs are processed **in-memory** and immediately discarded
+- We do **NOT** store your raw financial data in plaintext
+- **Anonymized analytics only**: SHA-256 session hash + rounded totals (assets to $1K, Zakat to $100)
+- **Encrypted sessions**: AES-256-GCM if you use multi-step calculations
+- We do **NOT** use your data to train AI models
+- We do **NOT** sell, share, or rent your data
+
+## Data Deletion
+- Use the \`delete_my_data\` tool to instantly delete all your ChatGPT session data
+- Web users: Settings → Danger Zone → Delete All Data / Delete Account
+- Contact: privacy@vora.dev
+
+## Encryption
+- Session data: AES-256-GCM (key in browser sessionStorage)
+- Saved calculations: AES-256-GCM (Managed or Sovereign zero-knowledge mode)
+- All data encrypted at rest and in transit (HTTPS)
+
+## Children's Privacy
+- Not intended for users under 13 (consistent with OpenAI's requirements)
+- Users under 18 should use under parental supervision
+
+## Open Source
+- Our entire codebase is open-source (AGPL v3) at github.com/naheed/zakah
+- Anyone can verify our encryption and privacy claims`;
+
+// ---------------------------------------------------------------------------
+// Terms of Service Summary (ChatGPT-readable version of zakatflow.org/terms)
+// ---------------------------------------------------------------------------
+const TERMS_SUMMARY = `# ZakatFlow Terms of Service Summary
+**Full terms:** https://zakatflow.org/terms
+
+## Service Description
+ZakatFlow is a web-based tool that helps estimate Zakat obligations based on user-provided financial data. It supports 8 scholarly methodologies.
+
+## Guidance, Not Advice
+**Important:** ZakatFlow does NOT provide financial, tax, legal, or religious advice — whether accessed via the web or ChatGPT. All calculations are for educational and informational purposes only.
+
+We recommend you:
+- Consult qualified Islamic scholars for authoritative Zakat rulings
+- Consult tax professionals regarding tax implications
+- Verify calculations independently before making financial decisions
+
+## ChatGPT AI Integration (§8)
+- **Financial Disclaimer**: The AI may help organize your financial information, but calculations use scholarly methodologies — not AI judgment
+- **Multi-Methodology**: Supporting 8 methodologies does not constitute endorsement of any one approach
+- **Data Handling**: Inputs processed in-memory, immediately discarded (see Privacy Policy §4a)
+- **Age Restriction**: 13+ (OpenAI requirement), under 18 requires parental supervision
+- **Open Source**: AGPL v3 — inspect the code at github.com/naheed/zakah
+- **Third-Party**: Also subject to OpenAI's Terms of Use when using via ChatGPT
+
+## Warranties
+The Service is provided "AS IS" and "AS AVAILABLE." We cannot guarantee uninterrupted or error-free operation.
+
+## Intellectual Property
+Code is open-source under AGPL v3. The "ZakatFlow" brand name, logo, and hosted service are proprietary.
+
+## Governing Law
+State of California, United States.
+
+## Contact
+Email: privacy@vora.dev`;
+
+export function registerLegalTools(server: McpServer) {
+    server.tool(
+        "view_legal",
+        "View ZakatFlow's Privacy Policy or Terms of Service. Returns a structured summary of the requested legal document with a link to the full version on zakatflow.org.",
+        {
+            document: z.enum(["privacy", "terms"]).describe("Which legal document to view: 'privacy' for Privacy Policy, 'terms' for Terms of Service."),
+        },
+        async (params) => {
+            const { document } = params;
+
+            const content = document === "privacy" ? PRIVACY_SUMMARY : TERMS_SUMMARY;
+            const url = document === "privacy"
+                ? "https://zakatflow.org/privacy#chatgpt"
+                : "https://zakatflow.org/terms#chatgpt";
+
+            return {
+                content: [{
+                    type: "text" as const,
+                    text: `${content}\n\n---\n📄 **Read the full ${document === "privacy" ? "Privacy Policy" : "Terms of Service"}:** ${url}`
+                }]
+            };
+        }
+    );
+}

--- a/apps/web/src/content/privacy.ts
+++ b/apps/web/src/content/privacy.ts
@@ -209,7 +209,7 @@ export const privacySections: SectionContent[] = [
             },
             {
                 title: "4a.4 Session Data Deletion",
-                content: "You may request deletion of your ChatGPT session data at any time by contacting privacy@vora.dev with your ChatGPT user ID. Anonymized aggregate analytics (rounded totals) cannot be deleted as they contain no personally identifiable information."
+                content: "You can delete your ChatGPT session data instantly by asking ChatGPT to use the 'delete_my_data' tool. This will permanently remove your user record and all saved calculation sessions. Alternatively, you may contact privacy@vora.dev. Anonymized aggregate analytics (rounded totals) cannot be deleted as they contain no personally identifiable information."
             },
             {
                 title: "4a.5 Source Tracking",


### PR DESCRIPTION
## Summary
Closes #43 (Parent: #24)

### Two new MCP tools for self-service privacy compliance

#### `delete_my_data` — Self-Service Data Deletion
- **Preview mode** (`confirm: false`): shows what data would be deleted
- **Execution mode** (`confirm: true`): cascading delete (sessions → user)
- Guard rail prevents accidental deletion
- Graceful fallback if Supabase not configured
- Does NOT delete `zakat_anonymous_events` (non-PII, disclosed in response)

#### `view_legal` — Privacy & Terms Exposure
- Input: `"privacy"` or `"terms"`
- Returns ChatGPT-readable summaries with section headers
- Links to full documents at zakatflow.org

### Also Updated
- Privacy Policy §4a.4 now references `delete_my_data` (replaces email-only deletion)
- `index.ts` registers both tools

### Verification
- [x] **86/86** MCP server tests passed
- [x] **9 new tests**: content validation, module exports, Supabase fallback, privacy cross-ref