### PR TITLE
fix(mcp): rename schema params for LLM comprehension + compact deep links

### DIFF
--- a/apps/mcp-server/src/__tests__/tools.test.ts
+++ b/apps/mcp-server/src/__tests__/tools.test.ts
@@ -20,11 +20,11 @@ function buildFormDataFromToolInput(input: {
     gold_jewelry?: number;
     silver_value?: number;
     silver_jewelry?: number;
-    crypto_currency?: number;
+    crypto?: number;
     crypto_trading?: number;
     staked_assets?: number;
     stocks?: number;
-    short_term_investments?: number;
+    active_trading?: number;
     reits?: number;
     retirement?: number;
     revocable_trust?: number;
@@ -50,12 +50,12 @@ function buildFormDataFromToolInput(input: {
         goldJewelryValue: input.gold_jewelry || 0,
         silverInvestmentValue: input.silver_value || 0,
         silverJewelryValue: input.silver_jewelry || 0,
-        cryptoCurrency: input.crypto_currency || 0,
+        cryptoCurrency: input.crypto || 0,
         cryptoTrading: input.crypto_trading || 0,
         stakedAssets: input.staked_assets || 0,
-        hasCrypto: !!(input.crypto_currency || input.crypto_trading || input.staked_assets),
+        hasCrypto: !!(input.crypto || input.crypto_trading || input.staked_assets),
         passiveInvestmentsValue: (input.stocks || 0) + (input.reits || 0),
-        activeInvestments: input.short_term_investments || 0,
+        activeInvestments: input.active_trading || 0,
         fourOhOneKVestedBalance: input.retirement || 0,
         revocableTrustValue: input.revocable_trust || 0,
         irrevocableTrustValue: input.irrevocable_trust || 0,
@@ -192,7 +192,7 @@ describe('calculate_zakat — asset category parity', () => {
         const withoutCrypto = calculateZakat(buildFormDataFromToolInput({ cash: 10000 }));
         const withCrypto = calculateZakat(buildFormDataFromToolInput({
             cash: 10000,
-            crypto_currency: 5000,
+            crypto: 5000,
             crypto_trading: 3000,
             staked_assets: 2000,
         }));
@@ -287,7 +287,7 @@ describe('calculate_zakat — asset category parity', () => {
     it('short-term investments are 100% zakatable', () => {
         const withShortTerm = calculateZakat(buildFormDataFromToolInput({
             cash: 5000,
-            short_term_investments: 10000,
+            active_trading: 10000,
             madhab: 'bradford',
         }));
         // Cash 5000 + Short-term 10000 * 100% = 15000 * 0.025 = 375
@@ -405,7 +405,7 @@ describe('compare_madhabs tool — comparison logic', () => {
         const results = methodologies.map((madhab) => {
             const formData = buildFormDataFromToolInput({
                 cash: 5000,
-                crypto_currency: 10000,
+                crypto: 10000,
                 madhab,
             });
             return calculateZakat(formData);

--- a/apps/mcp-server/src/tools/compare_madhabs.ts
+++ b/apps/mcp-server/src/tools/compare_madhabs.ts
@@ -51,13 +51,13 @@ export function registerCompareMadhabs(server: McpServer) {
                 silver_jewelry: z.number().optional().describe("Value of wearable silver jewelry in USD."),
 
                 // ─── Crypto ──────────────────────────────────────────────
-                crypto_currency: z.number().optional().describe("Value of major crypto held as store of value (BTC, ETH)."),
-                crypto_trading: z.number().optional().describe("Value of altcoins, NFTs held for trading."),
+                crypto: z.number().optional().describe("Value of all cryptocurrency holdings (Bitcoin, Ethereum, etc). 100% zakatable."),
+                crypto_trading: z.number().optional().describe("Value of altcoins, NFTs held for active trading."),
                 staked_assets: z.number().optional().describe("Principal value of staked crypto."),
 
                 // ─── Investments ─────────────────────────────────────────
-                stocks: z.number().optional().describe("Value of long-term passive investments (stocks, index funds, ETFs)."),
-                short_term_investments: z.number().optional().describe("Value of active trading assets."),
+                stocks: z.number().optional().describe("Value of stocks, index funds, ETFs, mutual funds."),
+                active_trading: z.number().optional().describe("Value of day-trading portfolios or short-term investments."),
                 reits: z.number().optional().describe("Value of equity REIT investments."),
 
                 // ─── Retirement ──────────────────────────────────────────
@@ -89,8 +89,8 @@ export function registerCompareMadhabs(server: McpServer) {
             const {
                 methodologies, cash,
                 gold_value, gold_jewelry, silver_value, silver_jewelry,
-                crypto_currency, crypto_trading, staked_assets,
-                stocks, short_term_investments, reits,
+                crypto, crypto_trading, staked_assets,
+                stocks, active_trading, reits,
                 retirement,
                 revocable_trust, irrevocable_trust,
                 real_estate_for_sale, rental_income,
@@ -115,12 +115,12 @@ export function registerCompareMadhabs(server: McpServer) {
                     goldJewelryValue: gold_jewelry || 0,
                     silverInvestmentValue: silver_value || 0,
                     silverJewelryValue: silver_jewelry || 0,
-                    cryptoCurrency: crypto_currency || 0,
+                    cryptoCurrency: crypto || 0,
                     cryptoTrading: crypto_trading || 0,
                     stakedAssets: staked_assets || 0,
-                    hasCrypto: !!(crypto_currency || crypto_trading || staked_assets),
+                    hasCrypto: !!(crypto || crypto_trading || staked_assets),
                     passiveInvestmentsValue: (stocks || 0) + (reits || 0),
-                    activeInvestments: short_term_investments || 0,
+                    activeInvestments: active_trading || 0,
                     fourOhOneKVestedBalance: retirement || 0,
                     revocableTrustValue: revocable_trust || 0,
                     irrevocableTrustValue: irrevocable_trust || 0,


### PR DESCRIPTION
## Summary
Closes #45, Closes #46 (Parent: #24)

### Bug #45: ChatGPT Cant Map "stocks" and "crypto"
**Root cause:** Schema param `long_term_investments` is too technical — ChatGPT LLM cannot infer "stocks" maps to this param name.

**Fix:**
| Old Name | New Name | Rationale |
|----------|----------|-----------|
| `long_term_investments` | `stocks` | Matches natural user language |
| `short_term_investments` | `active_trading` | More descriptive |
| `crypto_currency` | `crypto` | Simpler, matches user intent |

Applied in both `calculate_zakat.ts` and `compare_madhabs.ts`.

### Bug #46: Deep Link URL Too Long
**Root cause:** `btoa(JSON.stringify(formData))` serializes all 60+ fields including zeros.

**Fix:** Strip zero-value numbers, empty strings, false booleans, and known defaults before encoding. A $50K cash calculation now produces ~100 bytes instead of ~2KB.

### Verification
- [x] 86/86 MCP server tests pass
- [x] All renames mirrored in test helper