### PR TITLE
fix(web): merge deep link payload onto defaultFormData to prevent NaN

### DIFF
--- a/apps/web/src/context/ZakatPersistenceContext.tsx
+++ b/apps/web/src/context/ZakatPersistenceContext.tsx
@@ -88,7 +88,7 @@ export function ZakatPersistenceProvider({ children }: { children: ReactNode }) 
 
                         // Validate/Safety check? (Basic check)
                         if (loadedData && typeof loadedData === 'object') {
-                            setFormData(loadedData);
+                            setFormData({ ...defaultFormData, ...loadedData });
                             setStepIndex(17); // Results Step Index
                             setReportReady(true);
                             setIsLoaded(true);


### PR DESCRIPTION
## Summary
Closes #49 (Parent: #24)

### Problem
Deep links from ChatGPT produce NaN on zakatflow.org. The compact deep link payload contains only 5 non-zero fields. `ZakatPersistenceContext.tsx` called `setFormData(loadedData)` which **replaced** the entire state, making 60+ fields undefined → NaN.

### Fix
One-line change:
```diff
- setFormData(loadedData);
+ setFormData({ ...defaultFormData, ...loadedData });
```

### Verification
- [x] 328/331 web tests pass (3 pre-existing PlaidMethod failures)
- [x] No TypeScript errors