### PR TITLE
feat(mcp): ChatGPT Apps SDK compliance — annotations, CSP, domain, titles

### DIFF
--- a/apps/mcp-server/src/tools/calculate_zakat.ts
+++ b/apps/mcp-server/src/tools/calculate_zakat.ts
@@ -29,7 +29,13 @@ export function registerCalculateZakat(server: McpServer) {
         server,
         "calculate_zakat",
         {
+            title: "Calculate Zakat",
             description: "Calculate Zakat obligation based on Islamic jurisprudence. Supports ALL asset categories: cash, precious metals, crypto, investments, retirement, trusts, real estate, business, illiquid assets, and detailed liabilities. Returns structured calculation data rendered as an interactive widget. NOTE: ZakatFlow provides calculations, not fatwas. Users should consult a qualified scholar for personal rulings.",
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+                openWorldHint: false,
+            },
             inputSchema: {
                 // ─── Liquid Assets ───────────────────────────────────────
                 cash: z.number().describe("Total liquid cash: checking accounts, savings, cash on hand, digital wallets (PayPal/Venmo/CashApp), and foreign currency combined."),

--- a/apps/mcp-server/src/tools/compare_madhabs.ts
+++ b/apps/mcp-server/src/tools/compare_madhabs.ts
@@ -35,7 +35,13 @@ export function registerCompareMadhabs(server: McpServer) {
         server,
         "compare_madhabs",
         {
+            title: "Compare Methodologies",
             description: "Compare Zakat calculations across 2-4 Islamic jurisprudence methodologies side-by-side. Supports ALL asset categories for accurate comparison. Shows how different schools of thought affect the Zakat obligation for the same financial inputs. NOTE: ZakatFlow provides calculations, not fatwas.",
+            annotations: {
+                readOnlyHint: true,
+                destructiveHint: false,
+                openWorldHint: false,
+            },
             inputSchema: {
                 methodologies: z.array(
                     z.enum(MADHAB_IDS)

--- a/apps/mcp-server/src/tools/delete_data.ts
+++ b/apps/mcp-server/src/tools/delete_data.ts
@@ -19,6 +19,12 @@ export function registerDeleteData(server: McpServer) {
             chatgpt_user_id: z.string().describe("Your ChatGPT user ID (provided by OpenAI). Ask the user to confirm their identity before proceeding."),
             confirm: z.boolean().describe("Must be true to execute deletion. Set to false to preview what would be deleted without actually deleting."),
         },
+        {
+            title: "Delete My Data",
+            readOnlyHint: false,
+            destructiveHint: true,
+            openWorldHint: false,
+        },
         async (params) => {
             const { chatgpt_user_id, confirm } = params;
 

--- a/apps/mcp-server/src/tools/discovery.ts
+++ b/apps/mcp-server/src/tools/discovery.ts
@@ -30,7 +30,14 @@ export function registerDiscoveryTools(server: McpServer) {
     // 1. List Methodologies
     server.tool(
         "list_methodologies",
+        "List all available Zakat calculation methodologies supported by ZakatFlow.",
         {},
+        {
+            title: "List Methodologies",
+            readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
+        },
         async () => {
             const list = AVAILABLE_PRESETS.map(p => ({
                 id: p.meta.id,
@@ -51,8 +58,15 @@ export function registerDiscoveryTools(server: McpServer) {
     // 2. Get Nisab Info
     server.tool(
         "get_nisab_info",
+        "Get the current Nisab threshold for a specific methodology.",
         {
             methodology_id: z.string().optional().describe("ID of the methodology to check. Defaults to 'bradford'."),
+        },
+        {
+            title: "Get Nisab Info",
+            readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         async ({ methodology_id }) => {
             const preset = ZAKAT_PRESETS[methodology_id || 'bradford'] || ZAKAT_PRESETS['bradford'];

--- a/apps/mcp-server/src/tools/interactive.ts
+++ b/apps/mcp-server/src/tools/interactive.ts
@@ -24,7 +24,14 @@ export function registerInteractiveTools(server: McpServer) {
     // Tool to start a session
     server.tool(
         "start_session",
+        "Start a new interactive Zakat calculation session for step-by-step asset entry.",
         {},
+        {
+            title: "Start Session",
+            readOnlyHint: false,
+            destructiveHint: false,
+            openWorldHint: false,
+        },
         async () => {
             const session = SessionStore.create();
             return {
@@ -37,10 +44,17 @@ export function registerInteractiveTools(server: McpServer) {
     // Tool to add assets
     server.tool(
         "add_asset",
+        "Add an asset to an existing Zakat calculation session.",
         {
             sessionId: z.string().describe("The widget session ID received from previous turns."),
             assetType: z.enum(['cash', 'gold', 'silver', 'stocks', 'retirement', 'loans']),
             amount: z.number().describe("The value or amount of the asset."),
+        },
+        {
+            title: "Add Asset",
+            readOnlyHint: false,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         async ({ sessionId, assetType, amount }) => {
             const session = SessionStore.get(sessionId);

--- a/apps/mcp-server/src/tools/legal.ts
+++ b/apps/mcp-server/src/tools/legal.ts
@@ -93,6 +93,12 @@ export function registerLegalTools(server: McpServer) {
         {
             document: z.enum(["privacy", "terms"]).describe("Which legal document to view: 'privacy' for Privacy Policy, 'terms' for Terms of Service."),
         },
+        {
+            title: "View Legal Documents",
+            readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
+        },
         async (params) => {
             const { document } = params;
 

--- a/apps/mcp-server/src/tools/market.ts
+++ b/apps/mcp-server/src/tools/market.ts
@@ -26,8 +26,15 @@ import {
 export function registerMarketTools(server: McpServer) {
     server.tool(
         "get_market_prices",
+        "Get current gold and silver market prices used for Nisab threshold calculations.",
         {
             currency: z.string().default("USD").describe("Currency to return prices in (Currently only USD supported).")
+        },
+        {
+            title: "Get Market Prices",
+            readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         async () => {
             const goldPerGram = GOLD_PRICE_PER_OUNCE / GRAMS_PER_OUNCE;

--- a/apps/mcp-server/src/tools/parse_blob.ts
+++ b/apps/mcp-server/src/tools/parse_blob.ts
@@ -21,8 +21,15 @@ import { z } from "zod";
 export function registerParseBlob(server: McpServer) {
     server.tool(
         "parse_blob_input",
+        "Parse unstructured text describing financial assets and extract structured asset values.",
         {
             blob: z.string().describe("The unstructured user text describing their assets."),
+        },
+        {
+            title: "Parse Financial Text",
+            readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         async ({ blob }: { blob: string }) => {
             const content: any[] = [];

--- a/apps/mcp-server/src/tools/reporting.ts
+++ b/apps/mcp-server/src/tools/reporting.ts
@@ -22,6 +22,7 @@ import { defaultFormData, ZakatFormData } from "@zakatflow/core";
 export function registerReportingTools(server: McpServer) {
     server.tool(
         "create_report_link",
+        "Generate a deep link to a full Zakat calculation report on ZakatFlow.org.",
         {
             cash: z.number().optional(),
             gold_value: z.number().optional(),
@@ -30,6 +31,12 @@ export function registerReportingTools(server: McpServer) {
             retirement: z.number().optional(),
             loans: z.number().optional(),
             madhab: z.enum(['bradford', 'hanafi', 'shafii', 'maliki', 'hanbali', 'amja', 'qaradawi']).optional(),
+        },
+        {
+            title: "Create Report Link",
+            readOnlyHint: true,
+            destructiveHint: false,
+            openWorldHint: false,
         },
         async ({ cash, gold_value, silver_value, stocks, retirement, loans, madhab }) => {
 

--- a/apps/mcp-server/src/widget/template.ts
+++ b/apps/mcp-server/src/widget/template.ts
@@ -170,7 +170,17 @@ export function registerWidgetTemplate(server: McpServer) {
                     _meta: {
                         ui: {
                             prefersBorder: true,
+                            domain: "https://mcp.zakatflow.org",
+                            csp: {
+                                connectDomains: [
+                                    "https://pcwdpsoheoiiavkeyeyx.supabase.co",
+                                ],
+                                resourceDomains: [
+                                    "https://*.oaistatic.com",
+                                ],
+                            },
                         },
+                        "openai/widgetDescription": "Interactive Zakat calculation showing amount due, methodology breakdown, and link to full report on ZakatFlow.org.",
                     },
                 },
             ],


### PR DESCRIPTION
## Summary
Closes #54, #55, #56 (Parent: #24)

### [#54](https://github.com/naheed/zakah/issues/54) — Tool Annotations (**required**)
All 9 tools now declare `readOnlyHint`, `destructiveHint`, `openWorldHint`.

| Tool | readOnly | destructive | openWorld |
|------|----------|-------------|-----------|
| calculate_zakat | ✅ | - | - |
| compare_madhabs | ✅ | - | - |
| get_market_prices | ✅ | - | - |
| view_legal | ✅ | - | - |
| list_methodologies | ✅ | - | - |
| get_nisab_info | ✅ | - | - |
| create_report_link | ✅ | - | - |
| parse_blob_input | ✅ | - | - |
| start_session | - | - | - |
| add_asset | - | - | - |
| delete_my_data | - | ✅ | - |

### [#55](https://github.com/naheed/zakah/issues/55) — Widget CSP + Domain (**required for submission**)
- `domain`: `https://mcp.zakatflow.org`
- `connectDomains`: Supabase project URL
- `resourceDomains`: oaistatic CDN
- `widgetDescription`: "Interactive Zakat calculation showing amount due..."

### [#56](https://github.com/naheed/zakah/issues/56) — Tool Titles
All 11 tools now have human-readable titles.

### Verification
- [x] 87/87 MCP server tests pass
- [x] No TypeScript lint errors