### PR TITLE
feat: auto-calculate AI swarm efficiency metrics in telemetry

### DIFF
--- a/.agents/telemetry/types.ts
+++ b/.agents/telemetry/types.ts
@@ -19,4 +19,10 @@ export interface AgentEvent {
 
     /** Whether the agent detected its own prior hallucination/error during self-reflection */
     hallucination_detected?: boolean;
+
+    /** Execution duration in milliseconds (computed automatically) */
+    duration_ms?: number;
+
+    /** Number of files modified during this execution (computed automatically) */
+    files_modified?: number;
 }


### PR DESCRIPTION
Upgrades the  module to stop relying on the LLM explicitly sending metrics like token counts. It now computes the real timestamp delta against the prior START event and analyzes the `git status` footprint to count files touched, removing the hallucination risk and providing hard data for agent review.